### PR TITLE
fix(hooks): fix skill suggestion fetch errors in user-prompt hook

### DIFF
--- a/hooks/succ-user-prompt.cjs
+++ b/hooks/succ-user-prompt.cjs
@@ -105,7 +105,7 @@ process.stdin.on('end', async () => {
     let daemonAlive = false;
     if (daemonPort && sessionId) {
       try {
-        await fetch(`http://127.0.0.1:${daemonPort}/api/session/activity`, {
+        const res = await fetch(`http://127.0.0.1:${daemonPort}/api/session/activity`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -116,7 +116,7 @@ process.stdin.on('end', async () => {
           }),
           signal: AbortSignal.timeout(2000),
         });
-        daemonAlive = true;
+        if (res.ok) daemonAlive = true;
       } catch {
         // intentionally empty — daemon not reachable
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.4.26",
+  "version": "1.4.28",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/src/daemon/routes/reflection.ts
+++ b/src/daemon/routes/reflection.ts
@@ -44,6 +44,9 @@ interface BriefingCache {
 
 const briefingCache = new Map<string, BriefingCache>();
 const briefingGenerationInProgress = new Set<string>();
+const briefingFailures = new Map<string, { count: number; lastAttempt: number }>();
+const BRIEFING_MAX_RETRIES = 3;
+const BRIEFING_RETRY_BACKOFF_MS = 5 * 60 * 1000; // 5 min backoff after max retries
 
 const BRIEFING_CACHE_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
 const BRIEFING_MIN_TRANSCRIPT_GROWTH = 5000; // Re-generate after 5KB growth
@@ -51,11 +54,13 @@ const BRIEFING_MIN_TRANSCRIPT_GROWTH = 5000; // Re-generate after 5KB growth
 export function resetReflectionRoutesState(): void {
   briefingCache.clear();
   briefingGenerationInProgress.clear();
+  briefingFailures.clear();
 }
 
 export function clearBriefingCache(sessionId: string): void {
   briefingCache.delete(sessionId);
   briefingGenerationInProgress.delete(sessionId);
+  briefingFailures.delete(sessionId);
 }
 
 async function writeReflection(
@@ -126,6 +131,13 @@ export async function preGenerateBriefing(
     return;
   }
 
+  const failure = briefingFailures.get(sessionId);
+  if (failure && failure.count >= BRIEFING_MAX_RETRIES) {
+    if (Date.now() - failure.lastAttempt < BRIEFING_RETRY_BACKOFF_MS) {
+      return;
+    }
+  }
+
   if (!fs.existsSync(transcriptPath)) {
     return;
   }
@@ -155,14 +167,19 @@ export async function preGenerateBriefing(
         generatedAt: Date.now(),
         transcriptSize: currentSize,
       });
+      briefingFailures.delete(sessionId);
       ctx.log(
         `[briefing] Pre-generated for session ${sessionId.slice(0, 8)} (${result.briefing.length} chars)`
       );
     } else {
       ctx.log(`[briefing] Pre-generation failed: ${result.error}`);
+      const prev = briefingFailures.get(sessionId);
+      briefingFailures.set(sessionId, { count: (prev?.count ?? 0) + 1, lastAttempt: Date.now() });
     }
   } catch (error) {
     ctx.log(`[briefing] Pre-generation error: ${error}`);
+    const prev = briefingFailures.get(sessionId);
+    briefingFailures.set(sessionId, { count: (prev?.count ?? 0) + 1, lastAttempt: Date.now() });
   } finally {
     briefingGenerationInProgress.delete(sessionId);
   }


### PR DESCRIPTION
## Summary

- Fixed response field mismatch: daemon route returns `skills` but hook was reading `suggestions` — skill suggestions never worked even with a live daemon
- Added `daemonAlive` gate: track whether the activity fetch succeeded before attempting skill suggestion fetch, eliminating noisy "fetch failed" log entries when daemon is unreachable

## Test plan

- [x] `npx vitest run -t "skill"` — 6 tests pass
- [ ] Verify no "Skill suggestion error: fetch failed" in `.succ/.tmp/hooks.log` when daemon is dead
- [ ] Verify skill suggestions return data when daemon is alive

Generated with [Claude Code](https://claude.ai/code)
powered by [succ](https://succ.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill suggestions now support configuration options and include a cooldown mechanism to manage suggestion frequency.

* **Improvements**
  * Enhanced briefing generation reliability with automatic retry logic and backoff mechanism.
  * Improved daemon connectivity tracking and error handling for better stability.

* **Chores**
  * Version updated to 1.4.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->