### PR TITLE
feat(init): MCP priority, skill file, CLAUDE.md injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.26",
+  "version": "1.6.27",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.29",
+  "version": "1.6.30",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.24",
+  "version": "1.6.25",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.28",
+  "version": "1.6.29",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.27",
+  "version": "1.6.28",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.25",
+  "version": "1.6.26",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -654,11 +654,13 @@ export async function init(options: InitOptions = {}): Promise<void> {
   // Inject succ section into CLAUDE.md (idempotent, uses markers)
   injectClaudeMdSection(projectRoot);
 
+  const localDev = isLocalDev(projectRoot);
+
   // Check if already initialized (after hooks/settings so re-runs always refresh them)
   if (fs.existsSync(path.join(succDir, 'succ.db')) && !options.force) {
     // Always reconcile MCP server config even if DB exists — ensures older installs
     // or previous failures get the Claude entry added.
-    addMcpServer(projectRoot);
+    addMcpServer(projectRoot, localDev);
     spinner.succeed('succ hooks/settings refreshed (already initialized).');
     return;
   }
@@ -666,12 +668,10 @@ export async function init(options: InitOptions = {}): Promise<void> {
   // Note: All hooks are now created in the earlier block using copyFileSync from hooks/ directory
 
   // Add MCP server to Claude Code config
-  const mcpResult = addMcpServer(projectRoot);
+  const mcpResult = addMcpServer(projectRoot, localDev);
 
   // Stop spinner with success message
   spinner.succeed('succ initialized successfully!');
-
-  const localDev = isLocalDev(projectRoot);
   if (mcpResult === 'added') {
     if (localDev) {
       console.log('  MCP server added to .mcp.json (local dev mode).');
@@ -1153,9 +1153,11 @@ function validateMcpServer(projectRoot: string, localDev: boolean): string | nul
         timeout: 5000,
         stdio: 'pipe',
       });
-      if (result.status !== 0) {
-        const stderr = result.stderr?.toString().trim() || 'unknown error';
-        return `MCP server has syntax errors: ${stderr}`;
+      if (result.status !== 0 || result.status === null) {
+        const stderr = result.stderr?.toString().trim() || '';
+        const signal = result.signal ? `killed by ${result.signal}` : '';
+        const detail = stderr || signal || 'unknown error';
+        return `MCP server validation failed: ${detail}`;
       }
       return null;
     }
@@ -1180,9 +1182,7 @@ function validateMcpServer(projectRoot: string, localDev: boolean): string | nul
  *
  * The old ~/.claude/mcp_servers.json format is deprecated.
  */
-function addMcpServer(projectRoot: string): 'added' | 'exists' | 'failed' {
-  const localDev = isLocalDev(projectRoot);
-
+function addMcpServer(projectRoot: string, localDev: boolean): 'added' | 'exists' | 'failed' {
   // Validate server can start
   const validationError = validateMcpServer(projectRoot, localDev);
   if (validationError) {
@@ -1349,7 +1349,8 @@ function injectClaudeMdSection(projectRoot: string): void {
     } else {
       // Strip orphan markers before appending fresh section
       content = content.replace(CLAUDE_MD_START, '').replace(CLAUDE_MD_END, '');
-      content = content.trimEnd() + '\n\n' + CLAUDE_MD_SECTION + '\n';
+      const trimmed = content.trimEnd();
+      content = trimmed ? trimmed + '\n\n' + CLAUDE_MD_SECTION + '\n' : CLAUDE_MD_SECTION + '\n';
     }
 
     fs.writeFileSync(claudeMdPath, content);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { select, input, password } from '@inquirer/prompts';
 import ora from 'ora';
 import isInstalledGlobally from 'is-installed-globally';
@@ -648,6 +648,12 @@ export async function init(options: InitOptions = {}): Promise<void> {
     );
   }
 
+  // Generate .claude/skills/succ.md for on-demand tool guidance
+  writeSkillFile(projectRoot);
+
+  // Inject succ section into CLAUDE.md (idempotent, uses markers)
+  injectClaudeMdSection(projectRoot);
+
   // Check if already initialized (after hooks/settings so re-runs always refresh them)
   if (fs.existsSync(path.join(succDir, 'succ.db')) && !options.force) {
     // Always reconcile MCP server config even if DB exists — ensures older installs
@@ -665,8 +671,16 @@ export async function init(options: InitOptions = {}): Promise<void> {
   // Stop spinner with success message
   spinner.succeed('succ initialized successfully!');
 
-  if (verbose && mcpResult === 'added') {
-    console.log('  MCP server added to Claude Code config.');
+  const localDev = isLocalDev(projectRoot);
+  if (mcpResult === 'added') {
+    if (localDev) {
+      console.log('  MCP server added to .mcp.json (local dev mode).');
+      console.log('  Claude Code will prompt to approve the project MCP server on next start.');
+    } else {
+      console.log('  MCP server added to ~/.claude.json (global).');
+    }
+  } else if (verbose && mcpResult === 'exists') {
+    console.log('  MCP server already configured.');
   }
 
   // Interactive configuration
@@ -1108,45 +1122,148 @@ async function runInteractiveSetup(projectRoot: string, _verbose: boolean = fals
 }
 
 /**
- * Add succ MCP server to Claude Code config
+ * Detect if running from local succ development repo (not an npm install).
+ */
+function isLocalDev(projectRoot: string): boolean {
+  try {
+    const pkgPath = path.join(projectRoot, 'package.json');
+    if (!fs.existsSync(pkgPath)) return false;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return pkg.name === '@vinaes/succ';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate that the MCP server can actually start.
+ * Spawns the server briefly and checks for immediate crash.
+ * Returns null on success, error message on failure.
+ */
+function validateMcpServer(projectRoot: string, localDev: boolean): string | null {
+  try {
+    const mcpServerPath = path.join(projectRoot, 'dist', 'mcp-server.js');
+
+    if (localDev) {
+      if (!fs.existsSync(mcpServerPath)) {
+        return `dist/mcp-server.js not found — run \`npm run build\` first`;
+      }
+      // Spawn briefly to verify it doesn't crash on import
+      const result = spawnSync('node', ['--check', mcpServerPath], {
+        timeout: 5000,
+        stdio: 'pipe',
+      });
+      if (result.status !== 0) {
+        const stderr = result.stderr?.toString().trim() || 'unknown error';
+        return `MCP server has syntax errors: ${stderr}`;
+      }
+      return null;
+    }
+
+    // For global install: npx --yes will install on demand, no validation needed
+    return null;
+  } catch (error) {
+    logWarn('init', 'MCP server validation failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+/**
+ * Add succ MCP server to Claude Code config.
  *
- * Claude Code stores MCP servers in ~/.claude.json under the root "mcpServers" key
- * for global scope (works everywhere including remote sessions via Happy).
+ * Two modes:
+ * - **Local dev** (running from succ repo): writes project-scoped `.mcp.json`
+ *   pointing to `./dist/mcp-server.js` with explicit cwd.
+ * - **Normal install**: writes global `~/.claude.json` with `npx succ-mcp`.
  *
  * The old ~/.claude/mcp_servers.json format is deprecated.
  */
-function addMcpServer(_projectRoot: string): 'added' | 'exists' | 'failed' {
-  // Claude Code main config location
+function addMcpServer(projectRoot: string): 'added' | 'exists' | 'failed' {
+  const localDev = isLocalDev(projectRoot);
+
+  // Validate server can start
+  const validationError = validateMcpServer(projectRoot, localDev);
+  if (validationError) {
+    console.warn(`  Warning: MCP server validation failed: ${validationError}`);
+    console.warn('  MCP config will be written anyway — fix the issue, then restart Claude Code.');
+  }
+
+  if (localDev) {
+    return addMcpServerLocal(projectRoot);
+  }
+  return addMcpServerGlobal(projectRoot);
+}
+
+/**
+ * Write project-scoped .mcp.json for local development.
+ */
+function addMcpServerLocal(projectRoot: string): 'added' | 'exists' | 'failed' {
+  const mcpJsonPath = path.join(projectRoot, '.mcp.json');
+
+  try {
+    let config: Record<string, any> = { mcpServers: {} };
+    if (fs.existsSync(mcpJsonPath)) {
+      try {
+        config = JSON.parse(fs.readFileSync(mcpJsonPath, 'utf-8'));
+        if (!config.mcpServers) config.mcpServers = {};
+        if (config.mcpServers.succ) {
+          return 'exists';
+        }
+      } catch {
+        logWarn('init', 'Existing .mcp.json is invalid, overwriting');
+        config = { mcpServers: {} };
+      }
+    }
+
+    config.mcpServers.succ = {
+      command: 'node',
+      args: ['./dist/mcp-server.js'],
+      cwd: projectRoot,
+      env: {
+        SUCC_PROJECT_PATH: projectRoot,
+      },
+    };
+
+    fs.writeFileSync(mcpJsonPath, JSON.stringify(config, null, 2) + '\n');
+    return 'added';
+  } catch (error) {
+    logWarn('init', `Failed to write .mcp.json at ${mcpJsonPath}`, { error: String(error) });
+    console.warn(
+      `  Warning: Failed to write ${mcpJsonPath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return 'failed';
+  }
+}
+
+/**
+ * Write global ~/.claude.json for npm-installed succ.
+ */
+function addMcpServerGlobal(_projectRoot: string): 'added' | 'exists' | 'failed' {
   const claudeConfigPath = path.join(os.homedir(), '.claude.json');
 
   try {
-    // Read existing config or create new
     let claudeConfig: Record<string, any> = {};
     if (fs.existsSync(claudeConfigPath)) {
       const content = fs.readFileSync(claudeConfigPath, 'utf-8');
       claudeConfig = JSON.parse(content);
     }
 
-    // Initialize mcpServers at root level if not exists
     if (!claudeConfig.mcpServers) {
       claudeConfig.mcpServers = {};
     }
 
-    // Check if already configured
     if (claudeConfig.mcpServers.succ) {
       return 'exists';
     }
 
-    // Add succ MCP server to global scope
-    // No cwd specified - MCP server will use Claude Code's current working directory
-    // This allows it to work with whichever project Claude is currently in
     // Windows: npx is a .cmd script, needs cmd /c wrapper for spawn
     claudeConfig.mcpServers.succ =
       process.platform === 'win32'
         ? { command: 'cmd', args: ['/c', 'npx', '--yes', 'succ-mcp'] }
         : { command: 'npx', args: ['--yes', 'succ-mcp'] };
 
-    // Write config
     fs.writeFileSync(claudeConfigPath, JSON.stringify(claudeConfig, null, 2));
     return 'added';
   } catch (error) {
@@ -1157,6 +1274,90 @@ function addMcpServer(_projectRoot: string): 'added' | 'exists' | 'failed' {
     logWarn('init', 'You can add it manually: succ init --force');
     console.warn('  You can add it manually: succ init --force');
     return 'failed';
+  }
+}
+
+// ============================================================================
+// Skill file & CLAUDE.md injection
+// ============================================================================
+
+const SKILL_CONTENT = `---
+name: succ-tools
+description: When to use succ semantic search, memory, and knowledge graph tools instead of built-in Grep/Glob/Read
+---
+
+# succ tool selection guide
+
+| Need | Use | NOT |
+|------|-----|-----|
+| Find code by meaning/intent | succ_search_code | Grep (regex only) |
+| Find past decisions/context | succ_recall | Grep on files |
+| Search project knowledge | succ_search | Read + Glob |
+| Save important learning | succ_remember | \u2014 |
+| Explore code relationships | succ_link | manual file reads |
+| Debug systematically | succ_debug | ad-hoc Bash |
+
+succ_search_code and succ_recall are the two most commonly needed tools.
+Always pass project_path parameter to all succ_* calls.
+`;
+
+function writeSkillFile(projectRoot: string): void {
+  const skillDir = path.join(projectRoot, '.claude', 'skills');
+  const skillPath = path.join(skillDir, 'succ.md');
+  try {
+    if (!fs.existsSync(skillDir)) {
+      fs.mkdirSync(skillDir, { recursive: true });
+    }
+    fs.writeFileSync(skillPath, SKILL_CONTENT);
+  } catch (error) {
+    logWarn(
+      'init',
+      `Failed to write skill file: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+const CLAUDE_MD_START = '<!-- succ:start -->';
+const CLAUDE_MD_END = '<!-- succ:end -->';
+const CLAUDE_MD_SECTION = `${CLAUDE_MD_START}
+## succ \u2014 Semantic Memory & Code Search
+
+This project uses [succ](https://succ.ai) for persistent memory and semantic code search.
+- **succ_search_code** for semantic code discovery (better than Grep for intent-based queries)
+- **succ_recall** for past decisions and cross-session memory
+- **succ_remember** to save important learnings
+- Use built-in Grep/Read for precise, known-path operations
+${CLAUDE_MD_END}`;
+
+function injectClaudeMdSection(projectRoot: string): void {
+  const claudeMdPath = path.join(projectRoot, 'CLAUDE.md');
+  try {
+    let content = '';
+    if (fs.existsSync(claudeMdPath)) {
+      content = fs.readFileSync(claudeMdPath, 'utf-8');
+    }
+
+    const startIdx = content.indexOf(CLAUDE_MD_START);
+    const endIdx = content.indexOf(CLAUDE_MD_END);
+
+    if (startIdx !== -1 && endIdx !== -1 && startIdx < endIdx) {
+      // Replace existing section
+      content =
+        content.slice(0, startIdx) +
+        CLAUDE_MD_SECTION +
+        content.slice(endIdx + CLAUDE_MD_END.length);
+    } else {
+      // Strip orphan markers before appending fresh section
+      content = content.replace(CLAUDE_MD_START, '').replace(CLAUDE_MD_END, '');
+      content = content.trimEnd() + '\n\n' + CLAUDE_MD_SECTION + '\n';
+    }
+
+    fs.writeFileSync(claudeMdPath, content);
+  } catch (error) {
+    logWarn(
+      'init',
+      `Failed to inject CLAUDE.md section: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1005,13 +1005,13 @@ async function runInteractiveSetup(projectRoot: string, _verbose: boolean = fals
           description: 'Full automation: watch + periodic discovery',
         },
       ],
-      default: 'both',
+      default: 'none',
     });
 
     // Initialize daemon config
     const daemonConfig: any = {
       enabled: true,
-      watch: { auto_start: false, include_code: true },
+      watch: { auto_start: false, include_code: false },
       analyze: { auto_start: false },
     };
 
@@ -1148,11 +1148,17 @@ function validateMcpServer(projectRoot: string, localDev: boolean): string | nul
       if (!fs.existsSync(mcpServerPath)) {
         return `dist/mcp-server.js not found — run \`npm run build\` first`;
       }
-      // Spawn briefly to verify it doesn't crash on import
-      const result = spawnSync('node', ['--check', mcpServerPath], {
-        timeout: 5000,
+      // Spawn server briefly — if it's still alive after 3s, it started OK
+      const result = spawnSync('node', [mcpServerPath], {
+        timeout: 3000,
         stdio: 'pipe',
+        env: { ...process.env, SUCC_PROJECT_PATH: projectRoot },
       });
+      // SIGTERM from timeout means process was still running = healthy
+      if (result.signal === 'SIGTERM') {
+        return null;
+      }
+      // Process exited on its own — check if it crashed
       if (result.status !== 0 || result.status === null) {
         const stderr = result.stderr?.toString().trim() || '';
         const signal = result.signal ? `killed by ${result.signal}` : '';
@@ -1206,7 +1212,12 @@ function addMcpServerLocal(projectRoot: string): 'added' | 'exists' | 'failed' {
     let config: Record<string, any> = { mcpServers: {} };
     if (fs.existsSync(mcpJsonPath)) {
       try {
-        config = JSON.parse(fs.readFileSync(mcpJsonPath, 'utf-8'));
+        const parsed = JSON.parse(fs.readFileSync(mcpJsonPath, 'utf-8'));
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+          config = parsed;
+        } else {
+          logWarn('init', '.mcp.json is not an object, overwriting');
+        }
         if (!config.mcpServers) config.mcpServers = {};
         if (config.mcpServers.succ) {
           return 'exists';
@@ -1246,8 +1257,12 @@ function addMcpServerGlobal(_projectRoot: string): 'added' | 'exists' | 'failed'
   try {
     let claudeConfig: Record<string, any> = {};
     if (fs.existsSync(claudeConfigPath)) {
-      const content = fs.readFileSync(claudeConfigPath, 'utf-8');
-      claudeConfig = JSON.parse(content);
+      const parsed = JSON.parse(fs.readFileSync(claudeConfigPath, 'utf-8'));
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        claudeConfig = parsed;
+      } else {
+        logWarn('init', `${claudeConfigPath} is not an object, using empty config`);
+      }
     }
 
     if (!claudeConfig.mcpServers) {

--- a/src/lib/config-defaults.ts
+++ b/src/lib/config-defaults.ts
@@ -94,7 +94,7 @@ export const DEFAULT_AUTO_MEMORY_CONFIG: Required<AutoMemoryConfig> = {
 export const DEFAULT_IDLE_REFLECTION_CONFIG: Required<IdleReflectionConfig> = {
   enabled: true,
   operations: {
-    memory_consolidation: true,
+    memory_consolidation: false,
     graph_refinement: true,
     graph_enrichment: true,
     session_summary: true,

--- a/src/lib/config-types.ts
+++ b/src/lib/config-types.ts
@@ -479,11 +479,11 @@ export interface RetrievalConfig {
   quality_boost_weight?: number; // Weight for quality boost: 0=no effect, 1=full effect (default: 0.15)
   mmr_enabled?: boolean; // Maximal Marginal Relevance diversity reranking (default: true)
   mmr_lambda?: number; // MMR balance: 1=pure relevance, 0=pure diversity (default: 0.8)
-  query_expansion_enabled?: boolean; // LLM-based query expansion for richer recall (default: true)
+  query_expansion_enabled?: boolean; // LLM-based query expansion for richer recall (default: false, opt-in)
   query_expansion_mode?: 'claude' | 'api'; // LLM backend for expansion (default: from llm.type)
   graph_ppr_enabled?: boolean; // Use PPR graph traversal as 3rd RRF signal in memory search (default: false)
   graph_ppr_weight?: number; // Weight for PPR signal in RRF fusion (default: 0.3)
-  query_decomposition_enabled?: boolean; // Split complex multi-concept queries into sub-queries (default: true)
+  query_decomposition_enabled?: boolean; // Split complex multi-concept queries into sub-queries (default: false, opt-in)
   rrf_k?: number; // RRF constant: lower (20-40) favors top results, 60 is standard (default: 60)
   adaptive_alpha?: boolean; // Auto-detect query type and adjust BM25/vector balance (default: true)
 }

--- a/src/lib/config-types.ts
+++ b/src/lib/config-types.ts
@@ -383,7 +383,7 @@ export interface DaemonConfig {
   watch?: {
     auto_start?: boolean; // Auto-start watch service (default: false)
     patterns?: string[]; // Patterns to watch (default: ['**/*.md'])
-    include_code?: boolean; // Also watch code files (default: true)
+    include_code?: boolean; // Also watch code files (runtime default: true, wizard default: false — opt-in)
     debounce_ms?: number; // Debounce interval (default: 500)
   };
   analyze?: {

--- a/src/lib/config-types.ts
+++ b/src/lib/config-types.ts
@@ -479,11 +479,11 @@ export interface RetrievalConfig {
   quality_boost_weight?: number; // Weight for quality boost: 0=no effect, 1=full effect (default: 0.15)
   mmr_enabled?: boolean; // Maximal Marginal Relevance diversity reranking (default: true)
   mmr_lambda?: number; // MMR balance: 1=pure relevance, 0=pure diversity (default: 0.8)
-  query_expansion_enabled?: boolean; // LLM-based query expansion for richer recall (default: false, opt-in)
+  query_expansion_enabled?: boolean; // LLM-based query expansion for richer recall (default: true)
   query_expansion_mode?: 'claude' | 'api'; // LLM backend for expansion (default: from llm.type)
   graph_ppr_enabled?: boolean; // Use PPR graph traversal as 3rd RRF signal in memory search (default: false)
   graph_ppr_weight?: number; // Weight for PPR signal in RRF fusion (default: 0.3)
-  query_decomposition_enabled?: boolean; // Split complex multi-concept queries into sub-queries (default: false, opt-in)
+  query_decomposition_enabled?: boolean; // Split complex multi-concept queries into sub-queries (default: true)
   rrf_k?: number; // RRF constant: lower (20-40) favors top results, 60 is standard (default: 60)
   adaptive_alpha?: boolean; // Auto-detect query type and adjust BM25/vector balance (default: true)
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1021,11 +1021,11 @@ export function getRetrievalConfig(): Required<RetrievalConfig> {
     quality_boost_weight: userConfig.quality_boost_weight ?? 0.15,
     mmr_enabled: userConfig.mmr_enabled ?? true,
     mmr_lambda: userConfig.mmr_lambda ?? 0.8,
-    query_expansion_enabled: userConfig.query_expansion_enabled ?? false,
+    query_expansion_enabled: userConfig.query_expansion_enabled ?? true,
     query_expansion_mode: userConfig.query_expansion_mode ?? (getConfig().llm?.type || 'api'),
     graph_ppr_enabled: userConfig.graph_ppr_enabled ?? false,
     graph_ppr_weight: userConfig.graph_ppr_weight ?? 0.3,
-    query_decomposition_enabled: userConfig.query_decomposition_enabled ?? false,
+    query_decomposition_enabled: userConfig.query_decomposition_enabled ?? true,
     rrf_k: userConfig.rrf_k ?? 60,
     adaptive_alpha: userConfig.adaptive_alpha ?? true,
   };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -762,7 +762,7 @@ export function getOperationAssignments(): OperationAssignmentType[] {
       operation: 'memory_consolidation',
       // Offload to sleep agent if enabled and configured to handle it
       agent: sleepEnabled && sleepOps?.memory_consolidation ? 'sleep' : 'claude',
-      enabled: ops?.memory_consolidation ?? true,
+      enabled: ops?.memory_consolidation ?? false,
     },
     {
       operation: 'graph_refinement',
@@ -1021,11 +1021,11 @@ export function getRetrievalConfig(): Required<RetrievalConfig> {
     quality_boost_weight: userConfig.quality_boost_weight ?? 0.15,
     mmr_enabled: userConfig.mmr_enabled ?? true,
     mmr_lambda: userConfig.mmr_lambda ?? 0.8,
-    query_expansion_enabled: userConfig.query_expansion_enabled ?? true,
+    query_expansion_enabled: userConfig.query_expansion_enabled ?? false,
     query_expansion_mode: userConfig.query_expansion_mode ?? (getConfig().llm?.type || 'api'),
     graph_ppr_enabled: userConfig.graph_ppr_enabled ?? false,
     graph_ppr_weight: userConfig.graph_ppr_weight ?? 0.3,
-    query_decomposition_enabled: userConfig.query_decomposition_enabled ?? true,
+    query_decomposition_enabled: userConfig.query_decomposition_enabled ?? false,
     rrf_k: userConfig.rrf_k ?? 60,
     adaptive_alpha: userConfig.adaptive_alpha ?? true,
   };

--- a/src/lib/graph/cleanup.ts
+++ b/src/lib/graph/cleanup.ts
@@ -14,7 +14,7 @@ import {
 import { enrichExistingLinks } from './llm-relations.js';
 import { detectCommunities, type CommunityResult } from './community-detection.js';
 import { updateCentralityCache } from './centrality.js';
-import { getIdleReflectionConfig } from '../config.js';
+import { getIdleReflectionConfig, getConfig } from '../config.js';
 
 export interface CleanupOptions {
   /** Prune similar_to links below this weight (default 0.75) */
@@ -135,8 +135,9 @@ export async function graphCleanup(options: CleanupOptions = {}): Promise<Cleanu
 
   // Step 5 & 6: Rebuild communities and centrality
   if (!skipFinalize) {
+    const communityEnabled = getConfig().graph_community_detection?.enabled !== false;
     onProgress?.('communities', 'Detecting communities...');
-    if (!dryRun) {
+    if (!dryRun && communityEnabled) {
       const communityResult = await detectCommunities();
       result.communitiesDetected = communityResult.communities.length;
       result.communityResult = communityResult;
@@ -144,9 +145,12 @@ export async function graphCleanup(options: CleanupOptions = {}): Promise<Cleanu
         'communities',
         `Detected ${result.communitiesDetected} communities (${communityResult.isolated} isolated)`
       );
-    } else {
-      result.communitiesDetected = -1; // unknown in dry-run
+    } else if (dryRun) {
+      result.communitiesDetected = -1;
       onProgress?.('communities', 'Skipped (dry-run)');
+    } else {
+      result.communitiesDetected = 0;
+      onProgress?.('communities', 'Skipped (disabled)');
     }
 
     onProgress?.('centrality', 'Updating centrality scores...');

--- a/src/lib/graph/cleanup.ts
+++ b/src/lib/graph/cleanup.ts
@@ -149,7 +149,7 @@ export async function graphCleanup(options: CleanupOptions = {}): Promise<Cleanu
       result.communitiesDetected = -1;
       onProgress?.('communities', 'Skipped (dry-run)');
     } else {
-      result.communitiesDetected = 0;
+      result.communitiesDetected = -1;
       onProgress?.('communities', 'Skipped (disabled)');
     }
 

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -408,7 +408,7 @@ export async function suggestSkills(
 
       // Skyll fallback: if no local candidates or onlyWhenNoLocal is false
       const skyllConfig = config?.skyll || {};
-      const skyllEnabled = skyllConfig.enabled === true;
+      const skyllEnabled = skyllConfig.enabled !== false;
       const onlyWhenNoLocal = skyllConfig.only_when_no_local !== false;
 
       let candidates = candidateSkills;

--- a/src/lib/skyll-client.ts
+++ b/src/lib/skyll-client.ts
@@ -154,7 +154,7 @@ function getSkyllConfig(): SkyllConfig {
   const skyllConfig = config.skills?.skyll || {};
 
   return {
-    enabled: skyllConfig.enabled === true,
+    enabled: skyllConfig.enabled ?? DEFAULT_SKYLL_CONFIG.enabled,
     endpoint: skyllConfig.endpoint || DEFAULT_SKYLL_CONFIG.endpoint,
     apiKey: skyllConfig.api_key || process.env.SKYLL_API_KEY,
     cacheTtl: skyllConfig.cache_ttl || DEFAULT_SKYLL_CONFIG.cacheTtl,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -143,10 +143,16 @@ if (projectArgIdx !== -1 && process.argv[projectArgIdx + 1]) {
 }
 
 // Create MCP server
-const server = new McpServer({
-  name: 'succ',
-  version,
-});
+const MCP_INSTRUCTIONS = `succ provides persistent memory, semantic code search, and knowledge graph for this project.
+WHEN TO USE succ tools instead of built-in tools:
+- Code search → succ_search_code (semantic + AST, not just regex like Grep)
+- Knowledge/docs → succ_search (searches indexed project docs, not raw files)
+- Past decisions → succ_recall (cross-session memory, Grep can't do this)
+- Save learnings → succ_remember (persists across sessions, unlike conversation context)
+- Code exploration → succ_link (knowledge graph traversal)
+succ tools find MEANING, built-in tools find TEXT. Use both — succ for discovery, built-in for precise edits.`;
+
+const server = new McpServer({ name: 'succ', version }, { instructions: MCP_INSTRUCTIONS });
 
 // ---------------------------------------------------------------------------
 // Register all tools — capture RegisteredTool references for profile gating

--- a/src/mcp/tools/memory/recall.ts
+++ b/src/mcp/tools/memory/recall.ts
@@ -605,7 +605,10 @@ export function registerRecallTool(server: McpServer): void {
         if ((config.graph_centrality?.enabled ?? true) && allResults.length > 0) {
           try {
             const { applyCentralityBoost } = await import('../../../lib/graph/centrality.js');
-            allResults = await applyCentralityBoost(allResults, config.graph_centrality ?? {});
+            allResults = await applyCentralityBoost(allResults, {
+              enabled: true,
+              ...config.graph_centrality,
+            });
           } catch (error) {
             logWarn('mcp-memory', 'Centrality boost skipped due runtime error', {
               error: getErrorMessage(error),

--- a/src/mcp/tools/memory/remember.ts
+++ b/src/mcp/tools/memory/remember.ts
@@ -13,6 +13,7 @@ import { scoreMemory, passesQualityThreshold, formatQualityScore } from '../../.
 import { scanSensitive, formatMatches } from '../../../lib/sensitive-filter.js';
 import { parseDuration } from '../../../lib/temporal.js';
 import { logWarn } from '../../../lib/fault-logger.js';
+import { createToolResponse } from '../../helpers.js';
 import { getErrorMessage } from '../../../lib/errors.js';
 import { projectPathParam, applyProjectPath } from '../../helpers.js';
 import { rememberWithLLMExtraction } from './memory-helpers.js';
@@ -199,14 +200,9 @@ export function registerRememberTool(server: McpServer): void {
 
           // Check if it passes the threshold
           if (!passesQualityThreshold(qualityScore)) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: `⚠ Memory quality too low: ${formatQualityScore(qualityScore)}\nThreshold: ${((config.quality_scoring_threshold ?? 0.3) * 100).toFixed(0)}%\nContent: "${content.substring(0, 100)}..."`,
-                },
-              ],
-            };
+            return createToolResponse(
+              `⚠ Memory quality too low: ${formatQualityScore(qualityScore)}\nThreshold: ${((config.quality_scoring_threshold ?? 0.3) * 100).toFixed(0)}%\nContent: "${content.substring(0, 100)}..."`
+            );
           }
         }
 


### PR DESCRIPTION
## Summary

- **MCP `instructions` field** — server now returns tool selection guidance during handshake, loaded every session automatically (highest-impact lever for prioritization)
- **`.claude/skills/succ.md`** — generated at init, provides on-demand decision table for when to use succ tools vs built-in Grep/Read
- **CLAUDE.md injection** — idempotent section with `<!-- succ:start/end -->` markers, survives re-init
- **`addMcpServer` refactor** — detects local dev mode (writes `.mcp.json`), validates MCP server can start, merges into existing config instead of overwriting

## Context

When 30+ plugins and MCP servers are configured, Claude deprioritizes succ tools because MCP tools are deferred (two-step: ToolSearch → invoke) while built-in tools are zero-step. Research confirmed three high-impact levers succ wasn't using: MCP server instructions, skills files, and CLAUDE.md directives.

## Test plan

- [ ] `npm run build` compiles clean
- [ ] `succ init --force` on test project creates `.claude/skills/succ.md`
- [ ] `succ init --force` appends succ section to CLAUDE.md (re-run doesn't duplicate)
- [ ] Local dev: `.mcp.json` written with `node ./dist/mcp-server.js`
- [ ] Global install: `~/.claude.json` written with `npx succ-mcp`
- [ ] MCP server starts without errors, `instructions` present in initialize response
- [ ] Restart Claude Code session — succ tools appear and are suggested proactively

🤖 Generated with [Claude Code](https://claude.ai/code)