### PR TITLE
Security hardening, hybrid search fixes, undercover improvements

### DIFF
--- a/hooks/core/daemon-boot.cjs
+++ b/hooks/core/daemon-boot.cjs
@@ -304,4 +304,44 @@ function ensureDaemonLazy(projectDir, succDir, logFn) {
   return null;
 }
 
-module.exports = { ensureDaemon, ensureDaemonLazy, getDaemonPort, checkDaemon, startDaemon };
+/**
+ * Read daemon auth token from .succ/.tmp/daemon.token.
+ * @param {string} succDir - Path to .succ directory
+ * @returns {string|null}
+ */
+function getDaemonToken(succDir) {
+  try {
+    const tokenFile = path.join(succDir, '.tmp', 'daemon.token');
+    if (fs.existsSync(tokenFile)) {
+      return fs.readFileSync(tokenFile, 'utf8').trim();
+    }
+  } catch (e) {
+    console.error(`[succ:daemon] Token file read failed: ${errMsg(e)}`);
+  }
+  return null;
+}
+
+/**
+ * Fetch wrapper that auto-injects daemon auth token.
+ * @param {string} url - Full URL
+ * @param {object} opts - Standard fetch options
+ * @param {string} succDir - Path to .succ directory
+ * @returns {Promise<Response>}
+ */
+function daemonFetch(url, opts, succDir) {
+  const token = getDaemonToken(succDir);
+  if (token) {
+    opts = { ...opts, headers: { ...opts.headers, Authorization: `Bearer ${token}` } };
+  }
+  return fetch(url, opts);
+}
+
+module.exports = {
+  ensureDaemon,
+  ensureDaemonLazy,
+  getDaemonPort,
+  checkDaemon,
+  startDaemon,
+  getDaemonToken,
+  daemonFetch,
+};

--- a/hooks/succ-permission.cjs
+++ b/hooks/succ-permission.cjs
@@ -7,7 +7,7 @@
  */
 
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 
 adapter.runHook('permission', async ({ agent, hookInput, projectDir, succDir }) => {
   const daemonPort = ensureDaemonLazy(projectDir, succDir);
@@ -17,12 +17,16 @@ adapter.runHook('permission', async ({ agent, hookInput, projectDir, succDir }) 
   }
 
   try {
-    const response = await fetch(`http://127.0.0.1:${daemonPort}/api/hooks/permission`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(hookInput),
-      signal: AbortSignal.timeout(2000),
-    });
+    const response = await daemonFetch(
+      `http://127.0.0.1:${daemonPort}/api/hooks/permission`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(hookInput),
+        signal: AbortSignal.timeout(2000),
+      },
+      succDir
+    );
 
     if (response.ok) {
       const result = await response.json();

--- a/hooks/succ-post-tool.cjs
+++ b/hooks/succ-post-tool.cjs
@@ -16,7 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 
 const SOURCE_CONTEXT_MAX_CHARS = 2000;
 
@@ -152,12 +152,16 @@ adapter.runHook('post-tool', async ({ agent, hookInput, projectDir, succDir }) =
           payload.source_context = sourceContext;
         }
       }
-      const response = await fetch(`http://127.0.0.1:${daemonPort}/api/remember`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(3000),
-      });
+      const response = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/remember`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(3000),
+        },
+        succDir
+      );
       if (!response.ok) {
         console.error(
           `[succ:post-tool] succRemember failed: ${response.status} ${response.statusText}`
@@ -310,16 +314,20 @@ adapter.runHook('post-tool', async ({ agent, hookInput, projectDir, succDir }) =
                 console.error('[succ] MEMORY.md bullet blocked: injection detected');
                 return Promise.resolve();
               }
-              return fetch(`http://127.0.0.1:${daemonPort}/api/remember`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  content: bullet.text,
-                  tags: bullet.tags,
-                  source: 'memory-md-sync',
-                }),
-                signal: AbortSignal.timeout(5000),
-              })
+              return daemonFetch(
+                `http://127.0.0.1:${daemonPort}/api/remember`,
+                {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    content: bullet.text,
+                    tags: bullet.tags,
+                    source: 'memory-md-sync',
+                  }),
+                  signal: AbortSignal.timeout(5000),
+                },
+                succDir
+              )
                 .then((res) => {
                   if (!res.ok) {
                     console.error(

--- a/hooks/succ-pre-compact.cjs
+++ b/hooks/succ-pre-compact.cjs
@@ -15,6 +15,7 @@
 const fs = require('fs');
 const path = require('path');
 const adapter = require('./core/adapter.cjs');
+const { daemonFetch } = require('./core/daemon-boot.cjs');
 
 // Logging helper
 function log(succDir, message) {
@@ -241,12 +242,16 @@ process.stdin.on('end', async () => {
       const portFile = path.join(tmpDir, 'daemon.port');
       if (fs.existsSync(portFile)) {
         const port = fs.readFileSync(portFile, 'utf8').trim();
-        fetch(`http://127.0.0.1:${port}/api/hooks/pre-compact`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(stats),
-          signal: AbortSignal.timeout(2000),
-        })
+        daemonFetch(
+          `http://127.0.0.1:${port}/api/hooks/pre-compact`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(stats),
+            signal: AbortSignal.timeout(2000),
+          },
+          succDir
+        )
           .then((res) => {
             if (!res.ok) {
               log(succDir, `Daemon notify failed: ${res.status} ${res.statusText}`);

--- a/hooks/succ-pre-tool.cjs
+++ b/hooks/succ-pre-tool.cjs
@@ -23,7 +23,7 @@
 const fs = require('fs');
 const path = require('path');
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 const { loadMergedConfig } = require('./core/config.cjs');
 
 // ─── Dangerous command patterns ──────────────────────────────────────
@@ -704,12 +704,16 @@ async function recallFileMemories(projectDir, succDir, fileName) {
   if (!port) return [];
 
   try {
-    const res = await fetch(`http://127.0.0.1:${port}/api/recall-by-tag`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tag: `file:${fileName}`, limit: 5 }),
-      signal: AbortSignal.timeout(2000),
-    });
+    const res = await daemonFetch(
+      `http://127.0.0.1:${port}/api/recall-by-tag`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tag: `file:${fileName}`, limit: 5 }),
+        signal: AbortSignal.timeout(2000),
+      },
+      succDir
+    );
     if (!res.ok) return [];
     const data = await res.json();
     return data.results || [];
@@ -724,12 +728,16 @@ async function fetchHookRules(projectDir, succDir, toolName, toolInput) {
   if (!port) return [];
 
   try {
-    const res = await fetch(`http://127.0.0.1:${port}/api/hook-rules`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool_name: toolName, tool_input: toolInput || {} }),
-      signal: AbortSignal.timeout(2000),
-    });
+    const res = await daemonFetch(
+      `http://127.0.0.1:${port}/api/hook-rules`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tool_name: toolName, tool_input: toolInput || {} }),
+        signal: AbortSignal.timeout(2000),
+      },
+      succDir
+    );
     if (!res.ok) return [];
     const data = await res.json();
     return data.rules || [];

--- a/hooks/succ-pre-tool.cjs
+++ b/hooks/succ-pre-tool.cjs
@@ -531,7 +531,7 @@ function loadConfig(projectDir) {
       customPatterns: Array.isArray(csg.customPatterns) ? csg.customPatterns : [],
     },
     undercover: merged.undercover === true,
-    includeCoAuthoredBy: merged.includeCoAuthoredBy !== false,
+    includeCoAuthoredBy: !merged.undercover && merged.includeCoAuthoredBy !== false,
     preCommitReview: merged.preCommitReview === true,
   };
 }
@@ -892,7 +892,8 @@ adapter.runHook('pre-tool', async ({ agent, hookInput, projectDir, succDir }) =>
         contextParts.push(`<undercover-reminder>
 UNDERCOVER: No AI attribution, no "Generated with", no "Co-Authored-By", no tool names, no AI labels.
 No AI-revealing branch names (claude/, copilot/, ai/).
-Write as a human developer. Match existing project style.
+No em dashes, no en dashes, no "Certainly!", no corporate filler. Write like a human dev.
+Match existing project style.
 </undercover-reminder>`);
         // Still inject pre-commit-review if enabled (independent of undercover)
         if (/\bgit\s+commit\b/.test(command) && config.preCommitReview) {

--- a/hooks/succ-pre-tool.cjs
+++ b/hooks/succ-pre-tool.cjs
@@ -927,9 +927,10 @@ MEDIUM and below — commit is OK, mention findings in summary.
   try {
     const port = ensureDaemonLazy(projectDir, succDir);
     if (port && hookInput.session_id) {
-      const usageRes = await fetch(
+      const usageRes = await daemonFetch(
         `http://127.0.0.1:${port}/api/context-usage?session_id=${encodeURIComponent(hookInput.session_id)}`,
-        { signal: AbortSignal.timeout(500) }
+        { signal: AbortSignal.timeout(500) },
+        succDir
       );
       if (usageRes.ok) {
         const usage = await usageRes.json();
@@ -939,9 +940,10 @@ MEDIUM and below — commit is OK, mention findings in summary.
             contextParts.push(advisory);
             // ACK: mark cooldown AFTER successful advisory push (prevents consumed cooldown on hook failure)
             // Store promise so we can await it before process.exit (unawaited fetch gets killed on exit)
-            contextUsageAckPromise = fetch(
+            contextUsageAckPromise = daemonFetch(
               `http://127.0.0.1:${port}/api/context-usage/ack?session_id=${encodeURIComponent(hookInput.session_id)}`,
-              { method: 'POST', signal: AbortSignal.timeout(300) }
+              { method: 'POST', signal: AbortSignal.timeout(300) },
+              succDir
             ).catch((e) => {
               console.error('[succ:pre-tool] context-usage ack failed:', e.message || e);
             });

--- a/hooks/succ-session-end.cjs
+++ b/hooks/succ-session-end.cjs
@@ -11,7 +11,7 @@
 
 const path = require('path');
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 const { log: _log } = require('./core/log.cjs');
 
 adapter.runHook('session-end', async ({ hookInput, projectDir, succDir }) => {
@@ -41,16 +41,20 @@ adapter.runHook('session-end', async ({ hookInput, projectDir, succDir }) => {
   // Tell daemon to unregister and process session
   // Daemon will handle transcript parsing, summarization, and memory saving asynchronously
   try {
-    const res = await fetch(`http://127.0.0.1:${daemonPort}/api/session/unregister`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        session_id: sessionId,
-        transcript_path: transcriptPath,
-        run_reflection: !isServiceSession, // Don't run reflection for service sessions
-      }),
-      signal: AbortSignal.timeout(5000),
-    });
+    const res = await daemonFetch(
+      `http://127.0.0.1:${daemonPort}/api/session/unregister`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          session_id: sessionId,
+          transcript_path: transcriptPath,
+          run_reflection: !isServiceSession, // Don't run reflection for service sessions
+        }),
+        signal: AbortSignal.timeout(5000),
+      },
+      succDir
+    );
     if (!res.ok) {
       log(`Unregister failed: ${res.status} ${res.statusText} for session ${sessionId}`);
     }

--- a/hooks/succ-session-start.cjs
+++ b/hooks/succ-session-start.cjs
@@ -94,7 +94,7 @@ AI-generated text has recognizable stylistic tells. Avoid ALL of these:
 - **Paired conjunctions overuse**: "both X and Y", "not only X but also Y" in every other sentence
 
 Write the way a tired developer writes at 2am: short, direct, no flourishes.
-Dashes in code (hyphens in CLI flags, minus signs, etc.) are fine — only typographic em/en dashes in prose are banned.
+Dashes in code (hyphens in CLI flags, minus signs, etc.) are fine - only typographic em/en dashes in prose are banned.
 
 ## Issue Comments
 Write issue and PR review comments as a developer, not an assistant.

--- a/hooks/succ-session-start.cjs
+++ b/hooks/succ-session-start.cjs
@@ -82,6 +82,20 @@ Write code the way a human developer would. Specifically:
 - Match the codebase's existing naming conventions, formatting, and idiom density.
 - If the project has sparse comments, write sparse comments. If verbose, match that.
 
+## Natural Language Style (anti-AI fingerprinting)
+AI-generated text has recognizable stylistic tells. Avoid ALL of these:
+- **Em dashes** (\\u2014), en dashes (\\u2013): use commas, parentheses, or split into two sentences instead
+- **Filler openers**: "Certainly!", "Great question!", "Sure!", "Absolutely!", "I'd be happy to"
+- **Hedge stacking**: "It's worth noting that", "It should be mentioned that", "Interestingly,"
+- **Overly structured lists** in commit messages or PR descriptions where prose would be natural
+- **Resumptive phrasing**: "As mentioned above", "To summarize", "In conclusion"
+- **Corporate passive voice**: "It was determined that" instead of "I found" or "We found"
+- **Excessive qualifiers**: "robust", "seamless", "comprehensive", "leverage", "utilize", "facilitate"
+- **Paired conjunctions overuse**: "both X and Y", "not only X but also Y" in every other sentence
+
+Write the way a tired developer writes at 2am: short, direct, no flourishes.
+Dashes in code (hyphens in CLI flags, minus signs, etc.) are fine — only typographic em/en dashes in prose are banned.
+
 ## Issue Comments
 Write issue and PR review comments as a developer, not an assistant.
 No "I'd be happy to help" or "Here's what I found" phrasing.

--- a/hooks/succ-session-start.cjs
+++ b/hooks/succ-session-start.cjs
@@ -20,7 +20,7 @@
 const fs = require('fs');
 const path = require('path');
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemon } = require('./core/daemon-boot.cjs');
+const { ensureDaemon, daemonFetch } = require('./core/daemon-boot.cjs');
 const { log: _log } = require('./core/log.cjs');
 const { loadMergedConfig } = require('./core/config.cjs');
 
@@ -102,13 +102,19 @@ BAD commit messages:
       try {
         normalizedProjectDir = fs.realpathSync.native(projectDir);
       } catch (e) {
-        log(`[undercover] realpathSync.native failed for projectDir, falling back to path.resolve: ${e.message || e}`);
+        log(
+          `[undercover] realpathSync.native failed for projectDir, falling back to path.resolve: ${e.message || e}`
+        );
         normalizedProjectDir = path.resolve(projectDir);
       }
       /** Check if path is a symlink or NTFS junction */
       function isSymlinkOrJunction(p) {
-        try { return fs.lstatSync(p).isSymbolicLink(); }
-        catch (e) { log(`[undercover] lstatSync failed for ${p}: ${e.message || e}`); return false; }
+        try {
+          return fs.lstatSync(p).isSymbolicLink();
+        } catch (e) {
+          log(`[undercover] lstatSync failed for ${p}: ${e.message || e}`);
+          return false;
+        }
       }
 
       /** Verify resolved path is a child of base directory */
@@ -188,11 +194,15 @@ BAD commit messages:
       // Check if settings.local.json is already tracked by git (hoisted for use in both gitignore and settings blocks)
       let isTracked = false;
       try {
-        require('child_process').execFileSync('git', ['ls-files', '--error-unmatch', '.claude/settings.local.json'], {
-          cwd: projectDir,
-          stdio: ['pipe', 'pipe', 'pipe'],
-          windowsHide: true,
-        });
+        require('child_process').execFileSync(
+          'git',
+          ['ls-files', '--error-unmatch', '.claude/settings.local.json'],
+          {
+            cwd: projectDir,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true,
+          }
+        );
         isTracked = true;
       } catch (e) {
         // Not tracked — this is the expected case
@@ -202,10 +212,14 @@ BAD commit messages:
       // Ensure .claude/.gitignore guards settings.local.json from being tracked (unconditional)
       try {
         if (isTracked) {
-          log('[undercover] settings.local.json is already tracked by git — skipping .gitignore mutation');
+          log(
+            '[undercover] settings.local.json is already tracked by git — skipping .gitignore mutation'
+          );
         } else {
           if (!fs.existsSync(claudeDir)) {
-            log('[undercover] .claude/ does not exist — skipping .gitignore ensure to avoid creating repo-visible artifacts');
+            log(
+              '[undercover] .claude/ does not exist — skipping .gitignore ensure to avoid creating repo-visible artifacts'
+            );
           } else {
             if (isSafeWriteTarget(claudeGitignore, 'claudeGitignore')) {
               let gitignoreContent = '';
@@ -259,7 +273,9 @@ BAD commit messages:
         if (needsSync) {
           // Lightweight inline sync — write undercover values
           if (!fs.existsSync(claudeDir)) {
-            log('[undercover] .claude/ does not exist — skipping self-heal to avoid creating repo-visible artifacts');
+            log(
+              '[undercover] .claude/ does not exist — skipping self-heal to avoid creating repo-visible artifacts'
+            );
             // Don't proceed with write — would create visible artifacts
           } else {
             let settings = {};
@@ -299,7 +315,9 @@ BAD commit messages:
                 }
               }
             } catch (snapshotErr) {
-              log(`[undercover] Failed to snapshot Claude settings (best-effort): ${snapshotErr.message || snapshotErr}`);
+              log(
+                `[undercover] Failed to snapshot Claude settings (best-effort): ${snapshotErr.message || snapshotErr}`
+              );
             }
             settings.includeGitInstructions = false;
             settings.includeCoAuthoredBy = false;
@@ -831,12 +849,16 @@ Place them BEFORE the succ lines. The only hard rule: succ is always the last fo
   if (isCompactEvent && daemonPort && hookInput.transcript_path && !isServiceSession) {
     log(`Generating compact briefing for ${hookInput.transcript_path}`);
     try {
-      const response = await fetch(`http://127.0.0.1:${daemonPort}/api/briefing`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ transcript_path: hookInput.transcript_path }),
-        signal: AbortSignal.timeout(8000), // 8s timeout - must complete before 10s hook timeout
-      });
+      const response = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/briefing`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ transcript_path: hookInput.transcript_path }),
+          signal: AbortSignal.timeout(8000), // 8s timeout - must complete before 10s hook timeout
+        },
+        succDir
+      );
       if (response.ok) {
         const result = await response.json();
         if (result.success && result.briefing) {
@@ -863,9 +885,13 @@ Place them BEFORE the succ lines. The only hard rule: succ is always the last fo
     // Phase 1: Pinned memories (Tier 1 — correction_count >= 2 or is_invariant)
     // Filter: skip observations (noisy subagent reports), limit to top 10 by priority_score
     try {
-      const response = await fetch(`http://127.0.0.1:${daemonPort}/api/pinned`, {
-        signal: AbortSignal.timeout(3000),
-      });
+      const response = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/pinned`,
+        {
+          signal: AbortSignal.timeout(3000),
+        },
+        succDir
+      );
       if (response.ok) {
         const data = await response.json();
         const allPinned = data.results || [];
@@ -894,12 +920,16 @@ Place them BEFORE the succ lines. The only hard rule: succ is always the last fo
 
     // Phase 2: Recent memories (excluding pinned to avoid duplication)
     try {
-      const response = await fetch(`http://127.0.0.1:${daemonPort}/api/recall`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: '', limit: 5 }),
-        signal: AbortSignal.timeout(3000),
-      });
+      const response = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/recall`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: '', limit: 5 }),
+          signal: AbortSignal.timeout(3000),
+        },
+        succDir
+      );
       if (response.ok) {
         const data = await response.json();
         const memories = (data.results || []).filter((m) => !pinnedIds.has(m.id));
@@ -922,9 +952,13 @@ Place them BEFORE the succ lines. The only hard rule: succ is always the last fo
   // Knowledge base stats via daemon API
   if (daemonPort) {
     try {
-      const response = await fetch(`http://127.0.0.1:${daemonPort}/api/status`, {
-        signal: AbortSignal.timeout(3000),
-      });
+      const response = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/status`,
+        {
+          signal: AbortSignal.timeout(3000),
+        },
+        succDir
+      );
       if (response.ok) {
         const status = await response.json();
         const docs = status.documents || 0;
@@ -965,7 +999,9 @@ Place them BEFORE the succ lines. The only hard rule: succ is always the last fo
               const pkgPath = require.resolve('@vinaes/succ/package.json', { paths: [__dirname] });
               installedVersion = require(pkgPath).version;
             } catch (_resolveErr) {
-              log(`require.resolve @vinaes/succ/package.json failed: ${_resolveErr.message || _resolveErr}`);
+              log(
+                `require.resolve @vinaes/succ/package.json failed: ${_resolveErr.message || _resolveErr}`
+              );
               try {
                 // .package-root breadcrumb (matches daemon-boot.cjs pattern)
                 const pkgRootFile = path.join(succDir, '.package-root');
@@ -1062,16 +1098,20 @@ Place them BEFORE the succ lines. The only hard rule: succ is always the last fo
   // transcriptPath and canonicalSessionId derived early — reuse here for consistency
   if (daemonPort) {
     try {
-      const res = await fetch(`http://127.0.0.1:${daemonPort}/api/session/register`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          session_id: canonicalSessionId,
-          transcript_path: transcriptPath,
-          is_service: isServiceSession,
-        }),
-        signal: AbortSignal.timeout(3000),
-      });
+      const res = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/session/register`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            session_id: canonicalSessionId,
+            transcript_path: transcriptPath,
+            is_service: isServiceSession,
+          }),
+          signal: AbortSignal.timeout(3000),
+        },
+        succDir
+      );
       if (!res.ok) {
         log(
           `Session register failed: ${res.status} ${res.statusText} session=${canonicalSessionId}`

--- a/hooks/succ-stop-reflection.cjs
+++ b/hooks/succ-stop-reflection.cjs
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 
 adapter.runHook('stop-reflection', async ({ hookInput, projectDir, succDir }) => {
   const tmpDir = path.join(succDir, '.tmp');
@@ -38,17 +38,21 @@ adapter.runHook('stop-reflection', async ({ hookInput, projectDir, succDir }) =>
     if (!daemonPort) return;
 
     try {
-      await fetch(`http://127.0.0.1:${daemonPort}/api/session/activity`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          session_id: sessionId,
-          type: 'stop',
-          transcript_path: transcriptPath,
-          is_service: isServiceSession,
-        }),
-        signal: AbortSignal.timeout(2000),
-      });
+      await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/session/activity`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            session_id: sessionId,
+            type: 'stop',
+            transcript_path: transcriptPath,
+            is_service: isServiceSession,
+          }),
+          signal: AbortSignal.timeout(2000),
+        },
+        succDir
+      );
     } catch (e) {
       console.error(`[succ:stop] Daemon stop notification failed: ${e.message || e}`);
     }

--- a/hooks/succ-subagent-stop.cjs
+++ b/hooks/succ-subagent-stop.cjs
@@ -7,7 +7,7 @@
  */
 
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 
 adapter.runHook('subagent-stop', async ({ hookInput, projectDir, succDir }) => {
   const daemonPort = ensureDaemonLazy(projectDir, succDir);
@@ -17,12 +17,16 @@ adapter.runHook('subagent-stop', async ({ hookInput, projectDir, succDir }) => {
   }
 
   try {
-    await fetch(`http://127.0.0.1:${daemonPort}/api/hooks/subagent-stop`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(hookInput),
-      signal: AbortSignal.timeout(2000),
-    });
+    await daemonFetch(
+      `http://127.0.0.1:${daemonPort}/api/hooks/subagent-stop`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(hookInput),
+        signal: AbortSignal.timeout(2000),
+      },
+      succDir
+    );
   } catch (err) {
     console.error(`[succ:subagent-stop] Daemon proxy failed: ${err.message || err}`);
   }

--- a/hooks/succ-task-completed.cjs
+++ b/hooks/succ-task-completed.cjs
@@ -8,7 +8,7 @@
  */
 
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 
 adapter.runHook('task-completed', async ({ hookInput, projectDir, succDir }) => {
   const daemonPort = ensureDaemonLazy(projectDir, succDir);
@@ -18,12 +18,16 @@ adapter.runHook('task-completed', async ({ hookInput, projectDir, succDir }) => 
   }
 
   try {
-    await fetch(`http://127.0.0.1:${daemonPort}/api/hooks/task-completed`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(hookInput),
-      signal: AbortSignal.timeout(2000),
-    });
+    await daemonFetch(
+      `http://127.0.0.1:${daemonPort}/api/hooks/task-completed`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(hookInput),
+        signal: AbortSignal.timeout(2000),
+      },
+      succDir
+    );
   } catch (err) {
     console.error(`[succ:task-completed] Daemon proxy failed: ${err.message || err}`);
   }

--- a/hooks/succ-user-prompt.cjs
+++ b/hooks/succ-user-prompt.cjs
@@ -13,7 +13,7 @@
 const path = require('path');
 const fs = require('fs');
 const adapter = require('./core/adapter.cjs');
-const { ensureDaemonLazy } = require('./core/daemon-boot.cjs');
+const { ensureDaemonLazy, daemonFetch } = require('./core/daemon-boot.cjs');
 const { log: _log } = require('./core/log.cjs');
 const { loadMergedConfig } = require('./core/config.cjs');
 
@@ -62,17 +62,21 @@ adapter.runHook('user-prompt', async ({ agent, hookInput, projectDir, succDir })
   let daemonAlive = false;
   if (daemonPort && sessionId) {
     try {
-      const res = await fetch(`http://127.0.0.1:${daemonPort}/api/session/activity`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          session_id: sessionId,
-          type: 'user_prompt',
-          transcript_path: transcriptPath,
-          is_service: isServiceSession,
-        }),
-        signal: AbortSignal.timeout(2000),
-      });
+      const res = await daemonFetch(
+        `http://127.0.0.1:${daemonPort}/api/session/activity`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            session_id: sessionId,
+            type: 'user_prompt',
+            transcript_path: transcriptPath,
+            is_service: isServiceSession,
+          }),
+          signal: AbortSignal.timeout(2000),
+        },
+        succDir
+      );
       if (res.ok) daemonAlive = true;
     } catch (e) {
       log(`Daemon activity notification failed: ${e.message || e}`);
@@ -114,12 +118,16 @@ adapter.runHook('user-prompt', async ({ agent, hookInput, projectDir, succDir })
       // Only suggest if cooldown has passed
       if (promptsSinceLastSuggestion >= cooldownPrompts || promptsSinceLastSuggestion === 0) {
         try {
-          const response = await fetch(`http://127.0.0.1:${daemonPort}/api/skills/suggest`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ prompt }),
-            signal: AbortSignal.timeout(15000), // 15s timeout for 2 LLM calls (extraction + ranking)
-          });
+          const response = await daemonFetch(
+            `http://127.0.0.1:${daemonPort}/api/skills/suggest`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ prompt }),
+              signal: AbortSignal.timeout(15000), // 15s timeout for 2 LLM calls (extraction + ranking)
+            },
+            succDir
+          );
 
           if (response.ok) {
             const data = await response.json();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.30",
+  "version": "1.6.31",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.35",
+  "version": "1.6.36",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.31",
+  "version": "1.6.32",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.32",
+  "version": "1.6.34",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.34",
+  "version": "1.6.35",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vinaes/succ",
-  "version": "1.6.36",
+  "version": "1.6.37",
   "description": "Semantic Understanding for Code Contexts — persistent memory for AI coding assistants (Claude Code, Cursor, Windsurf, Continue.dev)",
   "type": "module",
   "publishConfig": {

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -97,6 +97,27 @@ function getDaemonPidFile(projectDir?: string): string {
   return path.join(succDir, '.tmp', 'daemon.pid');
 }
 
+function getDaemonTokenFile(projectDir?: string): string {
+  const succDir = projectDir ? path.join(projectDir, '.succ') : getSuccDir();
+  return path.join(succDir, '.tmp', 'daemon.token');
+}
+
+/**
+ * Read daemon auth token from token file
+ */
+function getDaemonToken(projectDir?: string): string | null {
+  const tokenFile = getDaemonTokenFile(projectDir);
+  if (!fs.existsSync(tokenFile)) return null;
+  try {
+    return fs.readFileSync(tokenFile, 'utf8').trim();
+  } catch (err) {
+    logWarn('daemon-client', 'Daemon token file exists but unreadable', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
 // ============================================================================
 // Port Detection
 // ============================================================================
@@ -153,13 +174,19 @@ export function getDaemonPid(projectDir?: string): number | null {
 // HTTP Helpers
 // ============================================================================
 
-async function httpGet(port: number, path: string): Promise<any> {
+function buildAuthHeaders(projectDir?: string): Record<string, string> {
+  const token = getDaemonToken(projectDir);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function httpGet(port: number, urlPath: string, projectDir?: string): Promise<any> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5000);
 
   try {
-    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+    const response = await fetch(`http://127.0.0.1:${port}${urlPath}`, {
       method: 'GET',
+      headers: buildAuthHeaders(projectDir),
       signal: controller.signal,
     });
 
@@ -173,14 +200,19 @@ async function httpGet(port: number, path: string): Promise<any> {
   }
 }
 
-async function httpPost(port: number, path: string, body: any): Promise<any> {
+async function httpPost(
+  port: number,
+  urlPath: string,
+  body: any,
+  projectDir?: string
+): Promise<any> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10000);
 
   try {
-    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+    const response = await fetch(`http://127.0.0.1:${port}${urlPath}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...buildAuthHeaders(projectDir) },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
@@ -216,7 +248,7 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return false;
 
       try {
-        const health = await httpGet(port, '/health');
+        const health = await httpGet(port, '/health', resolvedProjectDir);
         return health?.status === 'ok';
       } catch (err) {
         logWarn('daemon-client', 'Daemon health check failed (isRunning)', {
@@ -231,7 +263,7 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return null;
 
       try {
-        return await httpGet(port, '/health');
+        return await httpGet(port, '/health', resolvedProjectDir);
       } catch (err) {
         logWarn('daemon-client', 'Daemon call failed: getHealth', {
           error: err instanceof Error ? err.message : String(err),
@@ -250,11 +282,16 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return false;
 
       try {
-        const result = await httpPost(port, '/api/session/register', {
-          session_id: sessionId,
-          transcript_path: transcriptPath,
-          is_service: isService,
-        });
+        const result = await httpPost(
+          port,
+          '/api/session/register',
+          {
+            session_id: sessionId,
+            transcript_path: transcriptPath,
+            is_service: isService,
+          },
+          resolvedProjectDir
+        );
         return result?.success === true;
       } catch (err) {
         logWarn('daemon-client', 'Daemon call failed: registerSession', {
@@ -272,10 +309,15 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return { success: false, remaining_sessions: -1 };
 
       try {
-        return await httpPost(port, '/api/session/unregister', {
-          session_id: sessionId,
-          run_reflection: runReflection,
-        });
+        return await httpPost(
+          port,
+          '/api/session/unregister',
+          {
+            session_id: sessionId,
+            run_reflection: runReflection,
+          },
+          resolvedProjectDir
+        );
       } catch (error) {
         logWarn('client', 'Daemon call failed: unregisterSession', {
           error: error instanceof Error ? error.message : String(error),
@@ -294,12 +336,17 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return false;
 
       try {
-        const result = await httpPost(port, '/api/session/activity', {
-          session_id: sessionId,
-          type,
-          transcript_path: transcriptPath,
-          is_service: isService,
-        });
+        const result = await httpPost(
+          port,
+          '/api/session/activity',
+          {
+            session_id: sessionId,
+            type,
+            transcript_path: transcriptPath,
+            is_service: isService,
+          },
+          resolvedProjectDir
+        );
         return result?.success === true;
       } catch (error) {
         logWarn('client', 'Daemon call failed: sessionActivity', {
@@ -315,7 +362,7 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
 
       try {
         const endpoint = includeService ? '/api/sessions?includeService=true' : '/api/sessions';
-        const result = await httpGet(port, endpoint);
+        const result = await httpGet(port, endpoint, resolvedProjectDir);
         return result?.sessions || {};
       } catch (error) {
         logWarn('client', 'Daemon call failed: getSessions', {
@@ -331,7 +378,12 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return [];
 
       try {
-        const result = await httpPost(port, '/api/search', { query, limit, threshold });
+        const result = await httpPost(
+          port,
+          '/api/search',
+          { query, limit, threshold },
+          resolvedProjectDir
+        );
         return result?.results || [];
       } catch (error) {
         logWarn('client', 'Daemon call failed: search', {
@@ -346,7 +398,12 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return [];
 
       try {
-        const result = await httpPost(port, '/api/search-code', { query, limit });
+        const result = await httpPost(
+          port,
+          '/api/search-code',
+          { query, limit },
+          resolvedProjectDir
+        );
         return result?.results || [];
       } catch (error) {
         logWarn('client', 'Daemon call failed: searchCode', {
@@ -361,7 +418,12 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return [];
 
       try {
-        const result = await httpPost(port, '/api/recall', { query, ...options });
+        const result = await httpPost(
+          port,
+          '/api/recall',
+          { query, ...options },
+          resolvedProjectDir
+        );
         return result?.results || [];
       } catch (err) {
         logWarn('daemon-client', 'Daemon call failed: recall', {
@@ -379,7 +441,7 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return { success: false };
 
       try {
-        return await httpPost(port, '/api/remember', { content, ...options });
+        return await httpPost(port, '/api/remember', { content, ...options }, resolvedProjectDir);
       } catch (err) {
         logWarn('daemon-client', 'Daemon call failed: remember', {
           error: err instanceof Error ? err.message : String(err),
@@ -394,7 +456,12 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return false;
 
       try {
-        const result = await httpPost(port, '/api/reflect', { session_id: sessionId, force });
+        const result = await httpPost(
+          port,
+          '/api/reflect',
+          { session_id: sessionId, force },
+          resolvedProjectDir
+        );
         return result?.success === true;
       } catch (error) {
         logWarn('client', 'Daemon call failed: triggerReflection', {
@@ -410,7 +477,7 @@ export function createDaemonClient(projectDir?: string): DaemonClient {
       if (!port) return null;
 
       try {
-        return await httpGet(port, '/api/status');
+        return await httpGet(port, '/api/status', resolvedProjectDir);
       } catch (err) {
         logWarn('daemon-client', 'Daemon call failed: getStatus', {
           error: err instanceof Error ? err.message : String(err),

--- a/src/daemon/routes/status.ts
+++ b/src/daemon/routes/status.ts
@@ -70,6 +70,13 @@ export function statusRoutes(ctx: RouteContext): RouteMap {
       };
     },
 
+    'POST /api/shutdown': async () => {
+      ctx.log('[shutdown] Shutdown requested via API');
+      // Respond before shutting down so the caller gets an ack
+      setTimeout(() => ctx.requestShutdown(), 100);
+      return { success: true, message: 'Shutting down' };
+    },
+
     'GET /api/services': async () => {
       const manager = requireSessionManager(ctx);
       return {

--- a/src/daemon/routes/status.ts
+++ b/src/daemon/routes/status.ts
@@ -73,7 +73,9 @@ export function statusRoutes(ctx: RouteContext): RouteMap {
     'POST /api/shutdown': async () => {
       ctx.log('[shutdown] Shutdown requested via API');
       // Respond before shutting down so the caller gets an ack
-      setTimeout(() => ctx.requestShutdown(), 100);
+      setTimeout(() => {
+        ctx.requestShutdown().catch((err) => ctx.log(`[shutdown] shutdown failed: ${err}`));
+      }, 100);
       return { success: true, message: 'Shutting down' };
     },
 

--- a/src/daemon/routes/types.ts
+++ b/src/daemon/routes/types.ts
@@ -37,6 +37,7 @@ export interface RouteContext {
   sessionManager: SessionManager | null;
   log: (message: string) => void;
   checkShutdown: () => void;
+  requestShutdown: () => Promise<void>;
   clearBriefingCache: (sessionId: string) => void;
   appendToProgressFile: (sessionId: string, briefing: string) => void;
   readTailTranscript: (transcriptPath: string, maxBytes?: number) => string;

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -537,19 +537,26 @@ async function reclaimStablePort(
 
   // Same project — try graceful HTTP shutdown first, then force kill
   const occupantPid = health.pid;
-  logFn(`[daemon] Stale daemon on port ${stablePort} (pid=${occupantPid}), requesting shutdown`);
 
   // Read old daemon's auth token for authenticated shutdown request
   let tokenHeader: Record<string, string> = {};
+  let hasToken = false;
   try {
     const tokenPath = getDaemonTokenFile();
     if (fs.existsSync(tokenPath)) {
       const token = fs.readFileSync(tokenPath, 'utf8').trim();
-      if (token) tokenHeader = { Authorization: `Bearer ${token}` };
+      if (token) {
+        tokenHeader = { Authorization: `Bearer ${token}` };
+        hasToken = true;
+      }
     }
   } catch {
     logFn(`[daemon] Could not read old daemon token, shutdown request may be rejected`);
   }
+
+  logFn(
+    `[daemon] Stale daemon on port ${stablePort} (pid=${occupantPid}), requesting shutdown${hasToken ? '' : ' (no auth token, may be rejected)'}`
+  );
 
   try {
     const controller = new AbortController();

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -203,6 +203,7 @@ function createRouteContext(): RouteContext {
     sessionManager,
     log,
     checkShutdown,
+    requestShutdown: shutdownDaemon,
     clearBriefingCache,
     appendToProgressFile,
     readTailTranscript,
@@ -455,6 +456,138 @@ function scheduleUpdateCheck(logFn: (msg: string) => void): void {
   updateCheckTimer.unref(); // Don't prevent process exit
 }
 
+// ---------------------------------------------------------------------------
+// Port acquisition helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Try to bind a server to a port. Returns { ok: true } or { ok: false, code }. */
+async function tryListen(
+  server: http.Server,
+  port: number
+): Promise<{ ok: true } | { ok: false; code: string }> {
+  return new Promise((resolve) => {
+    const onError = (err: NodeJS.ErrnoException) => {
+      server.removeListener('listening', onListening);
+      resolve({ ok: false, code: err.code || 'UNKNOWN' });
+    };
+    const onListening = () => {
+      server.removeListener('error', onError);
+      resolve({ ok: true });
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+/**
+ * Probe the occupant of the stable port and decide what to do.
+ * Returns:
+ *   'exit'    — healthy daemon for this project, caller should exit
+ *   'killed'  — old daemon killed, caller should retry listen
+ *   'foreign' — port occupied by a non-succ process, caller should fallback
+ */
+async function reclaimStablePort(
+  stablePort: number,
+  ourCwd: string,
+  logFn: (msg: string) => void
+): Promise<'exit' | 'killed' | 'foreign'> {
+  // Probe health with retries (2 attempts, 1s apart) to survive GC pauses
+  let health: { status?: string; pid?: number; cwd?: string } | null = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3000);
+      const resp = await fetch(`http://127.0.0.1:${stablePort}/health`, {
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      if (resp.ok) {
+        health = (await resp.json()) as { status?: string; pid?: number; cwd?: string };
+        break;
+      }
+    } catch (probeErr) {
+      logFn(
+        `[daemon] Health probe attempt ${attempt + 1} failed: ${probeErr instanceof Error ? probeErr.message : String(probeErr)}`
+      );
+      if (attempt === 0) await sleep(1000);
+    }
+  }
+
+  if (!health || health.status !== 'ok') {
+    // Port occupied by something that doesn't respond to /health — foreign process
+    logFn(`[daemon] Stable port ${stablePort} occupied by non-succ process`);
+    return 'foreign';
+  }
+
+  // Normalize cwd for comparison (lowercase + forward slashes on Windows)
+  const normCwd = (p: string) =>
+    (process.platform === 'win32' ? p.toLowerCase() : p).replace(/\\/g, '/');
+
+  if (normCwd(health.cwd || '') !== normCwd(ourCwd)) {
+    logFn(
+      `[daemon] Stable port ${stablePort} used by different project: ${health.cwd} (ours: ${ourCwd})`
+    );
+    return 'foreign';
+  }
+
+  // Same project — try graceful HTTP shutdown first, then force kill
+  const occupantPid = health.pid;
+  logFn(`[daemon] Stale daemon on port ${stablePort} (pid=${occupantPid}), requesting shutdown`);
+
+  // Read old daemon's auth token for authenticated shutdown request
+  let tokenHeader: Record<string, string> = {};
+  try {
+    const tokenPath = getDaemonTokenFile();
+    if (fs.existsSync(tokenPath)) {
+      const token = fs.readFileSync(tokenPath, 'utf8').trim();
+      if (token) tokenHeader = { Authorization: `Bearer ${token}` };
+    }
+  } catch {
+    logFn(`[daemon] Could not read old daemon token, shutdown request may be rejected`);
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    await fetch(`http://127.0.0.1:${stablePort}/api/shutdown`, {
+      method: 'POST',
+      headers: tokenHeader,
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    // Wait for graceful exit
+    await sleep(2000);
+  } catch {
+    logFn(`[daemon] HTTP shutdown request failed, proceeding to kill`);
+  }
+
+  // Check if it's gone
+  if (occupantPid) {
+    try {
+      process.kill(occupantPid, 0);
+      // Still alive — force kill (on Windows, SIGKILL maps to TerminateProcess)
+      logFn(`[daemon] Daemon pid=${occupantPid} still alive after shutdown request, killing`);
+      try {
+        process.kill(occupantPid, 'SIGKILL');
+      } catch (killErr) {
+        logWarn('daemon', `Failed to kill stale daemon pid=${occupantPid}`, {
+          error: killErr instanceof Error ? killErr.message : String(killErr),
+        });
+      }
+      await sleep(500);
+    } catch {
+      logFn(`[daemon] Occupant pid=${occupantPid} already exited`);
+    }
+  }
+
+  return 'killed';
+}
+
 export async function startDaemon(): Promise<{ port: number; pid: number }> {
   if (state?.server) {
     return { port: state.port, pid: process.pid };
@@ -471,35 +604,38 @@ export async function startDaemon(): Promise<{ port: number; pid: number }> {
       try {
         const existingPid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10);
         if (!isNaN(existingPid) && existingPid && existingPid !== process.pid) {
+          let processAlive = false;
           try {
-            process.kill(existingPid, 0); // alive?
-            log(`[daemon] Another daemon running or initializing (pid=${existingPid}), exiting`);
-            process.exit(0);
+            process.kill(existingPid, 0);
+            processAlive = true;
           } catch (killErr) {
-            // Only reclaim on ESRCH (no such process).
-            // EPERM means the process exists but we lack permission — do NOT reclaim.
             const killCode = (killErr as NodeJS.ErrnoException).code;
             if (killCode !== 'ESRCH') {
               throw killErr;
             }
-            // Dead PID — atomic reclaim: unlink + exclusive create
-            log(`[daemon] PID ${existingPid} not running (${killCode}), reclaiming`);
-            try {
-              fs.unlinkSync(pidFile);
-            } catch (unlinkErr) {
-              if ((unlinkErr as NodeJS.ErrnoException).code !== 'ENOENT') {
-                throw unlinkErr;
-              }
+          }
+          // Reclaim PID file regardless — port acquisition will health-check the occupant
+          log(
+            processAlive
+              ? `[daemon] Existing daemon pid=${existingPid} alive, reclaiming PID (port acquisition will resolve)`
+              : `[daemon] PID ${existingPid} not running, reclaiming`
+          );
+          try {
+            fs.unlinkSync(pidFile);
+          } catch (unlinkErr) {
+            if ((unlinkErr as NodeJS.ErrnoException).code !== 'ENOENT') {
+              throw unlinkErr;
             }
-            try {
-              fs.writeFileSync(pidFile, String(process.pid), { flag: 'wx' });
-            } catch (reclaimErr) {
-              log(
-                `[daemon] Lost PID reclaim race (${(reclaimErr as NodeJS.ErrnoException).code || 'unknown'}), exiting`
-              );
-              process.exit(0);
-            }
-            // Also clean stale port file
+          }
+          try {
+            fs.writeFileSync(pidFile, String(process.pid), { flag: 'wx' });
+          } catch (reclaimErr) {
+            log(
+              `[daemon] Lost PID reclaim race (${(reclaimErr as NodeJS.ErrnoException).code || 'unknown'}), exiting`
+            );
+            process.exit(0);
+          }
+          if (!processAlive) {
             const portFile = getDaemonPortFile();
             try {
               fs.unlinkSync(portFile);
@@ -592,32 +728,48 @@ export async function startDaemon(): Promise<{ port: number; pid: number }> {
   const fallbackStart = config.daemon?.port_range_start ?? DEFAULT_PORT_RANGE_START;
 
   let port = stablePort;
-  let portAttempts = 0;
-  const maxAttempts = 1 + MAX_PORT_ATTEMPTS; // 1 stable + 100 fallback
 
-  for (let i = 0; i < maxAttempts; i++) {
-    await new Promise<void>((resolve, reject) => {
-      server.once('error', (err: NodeJS.ErrnoException) => {
-        if (err.code === 'EADDRINUSE') {
-          portAttempts++;
-          if (portAttempts === 1) {
-            // Stable port busy — switch to fallback range
-            port = fallbackStart;
-          } else {
-            port++;
+  // Attempt to bind the stable port. If occupied, probe occupant before falling back.
+  const stableBindResult = await tryListen(server, port);
+  if (!stableBindResult.ok) {
+    if (stableBindResult.code === 'EADDRINUSE') {
+      const reclaimed = await reclaimStablePort(stablePort, cwd, log);
+      if (reclaimed === 'exit') {
+        // Healthy daemon for this project already running — exit silently
+        log(`[daemon] Healthy daemon already on port ${stablePort}, exiting`);
+        process.exit(0);
+      }
+      if (reclaimed === 'killed') {
+        // Old daemon killed — retry listen with exponential backoff
+        let bound = false;
+        const delays = [100, 200, 400, 800, 1600];
+        for (const delay of delays) {
+          await sleep(delay);
+          const retry = await tryListen(server, stablePort);
+          if (retry.ok) {
+            bound = true;
+            break;
           }
-          resolve();
-        } else {
-          reject(err);
+          log(`[daemon] Stable port ${stablePort} still busy after ${delay}ms, retrying...`);
         }
-      });
-      server.listen(port, '127.0.0.1', () => {
-        resolve();
-      });
-    });
-
-    if (server.listening) {
-      break;
+        if (!bound) {
+          log(`[daemon] Could not reclaim stable port ${stablePort} after kill, falling back`);
+        }
+      }
+      // reclaimed === 'foreign' or retry exhausted — fall back to port scan
+      if (!server.listening) {
+        log(
+          `[daemon] Stable port ${stablePort} occupied by another process, scanning fallback range`
+        );
+        port = fallbackStart;
+        for (let i = 0; i < MAX_PORT_ATTEMPTS; i++) {
+          const result = await tryListen(server, port);
+          if (result.ok) break;
+          port++;
+        }
+      }
+    } else {
+      throw new NetworkError(`Failed to bind port ${port}: ${stableBindResult.code}`);
     }
   }
 
@@ -660,6 +812,9 @@ export async function startDaemon(): Promise<{ port: number; pid: number }> {
 
   // Daily recall event retention cleanup
   scheduleRecallCleanup(log);
+
+  // Max uptime guard — exit if idle for 24h+ so stale orphans self-terminate
+  scheduleMaxUptimeGuard(log);
 
   // Pre-warm WS transport if configured (eliminates cold-start on first LLM call)
   if (getClaudeMode() === 'ws') {
@@ -721,6 +876,9 @@ function setupShutdownHandlers(): void {
   });
 }
 
+const MAX_IDLE_UPTIME_MS = 24 * 3600_000; // 24 hours
+let maxUptimeTimer: ReturnType<typeof setInterval> | null = null;
+
 function checkShutdown(): void {
   if (sessionManager?.canShutdown()) {
     log(`[daemon] No more sessions and no pending work, scheduling shutdown`);
@@ -730,6 +888,19 @@ function checkShutdown(): void {
       }
     }, 5000);
   }
+}
+
+/** Periodic check: if daemon is idle and has exceeded max uptime, exit cleanly. */
+function scheduleMaxUptimeGuard(logFn: (msg: string) => void): void {
+  maxUptimeTimer = setInterval(() => {
+    if (!state?.startedAt || !sessionManager?.canShutdown()) return;
+    const uptime = Date.now() - state.startedAt;
+    if (uptime > MAX_IDLE_UPTIME_MS) {
+      logFn(`[daemon] Max idle uptime exceeded (${Math.round(uptime / 3600_000)}h), shutting down`);
+      shutdownDaemon();
+    }
+  }, 3600_000); // Check every hour
+  maxUptimeTimer.unref();
 }
 
 export async function shutdownDaemon(): Promise<void> {
@@ -748,6 +919,11 @@ export async function shutdownDaemon(): Promise<void> {
   if (recallCleanupStartupTimer) {
     clearTimeout(recallCleanupStartupTimer);
     recallCleanupStartupTimer = null;
+  }
+
+  if (maxUptimeTimer) {
+    clearInterval(maxUptimeTimer);
+    maxUptimeTimer = null;
   }
 
   if (recallCleanupTimer) {

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -15,6 +15,7 @@
  */
 
 import http from 'http';
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
@@ -142,14 +143,25 @@ export function readTailTranscript(
   return firstNewline > 0 ? content.slice(firstNewline + 1) : content;
 }
 
-function getDaemonPortFile(): string {
+function getDaemonTmpDir(): string {
   const succDir = getSuccDir();
   const tmpDir = path.join(succDir, '.tmp');
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir, { recursive: true });
   }
-  return path.join(tmpDir, 'daemon.port');
+  return tmpDir;
 }
+
+function getDaemonPortFile(): string {
+  return path.join(getDaemonTmpDir(), 'daemon.port');
+}
+
+function getDaemonTokenFile(): string {
+  return path.join(getDaemonTmpDir(), 'daemon.token');
+}
+
+// Auth token generated per daemon lifetime — written to .succ/.tmp/daemon.token
+let daemonToken: string | null = null;
 
 function getDaemonLogFile(): string {
   const succDir = getSuccDir();
@@ -222,14 +234,43 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
   const reqUrl = new URL(req.url || '/', `http://localhost`);
   const method = req.method || 'GET';
 
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  // Restrict CORS to localhost origins only — daemon should never be accessible from arbitrary sites
+  const origin = req.headers.origin;
+  if (origin && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 
   if (method === 'OPTIONS') {
     res.writeHead(204);
     res.end();
     return;
+  }
+
+  // Auth token check — skip for health/status/version (needed for discovery)
+  const pathname = reqUrl.pathname.replace(/^\/v1/, '');
+  const isPublicEndpoint =
+    pathname === '/health' ||
+    pathname === '/api/status' ||
+    pathname === '/api/version' ||
+    pathname === '/api/health';
+  if (daemonToken && !isPublicEndpoint) {
+    const authHeader = req.headers.authorization;
+    const providedToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    if (
+      !providedToken ||
+      Buffer.byteLength(providedToken) !== Buffer.byteLength(daemonToken) ||
+      !crypto.timingSafeEqual(Buffer.from(providedToken), Buffer.from(daemonToken))
+    ) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'Unauthorized. Provide daemon token via Authorization: Bearer <token>',
+        })
+      );
+      return;
+    }
   }
 
   let body: unknown = null;
@@ -594,8 +635,10 @@ export async function startDaemon(): Promise<{ port: number; pid: number }> {
   };
   cachedRoutes = null;
 
-  // PID already written at startup (atomic mutex). Write port now that we know it.
+  // PID already written at startup (atomic mutex). Write port and auth token now.
   fs.writeFileSync(getDaemonPortFile(), String(port));
+  daemonToken = crypto.randomBytes(32).toString('hex');
+  fs.writeFileSync(getDaemonTokenFile(), daemonToken, { mode: 0o600 });
 
   idleWatcher = createIdleWatcher({
     sessionManager,
@@ -766,6 +809,15 @@ export async function shutdownDaemon(): Promise<void> {
       log(`[shutdown] Port file removal failed: ${getErrorMessage(err)}`);
     }
   }
+
+  try {
+    fs.unlinkSync(getDaemonTokenFile());
+  } catch (err: unknown) {
+    if (!isErrnoException(err) || err.code !== 'ENOENT') {
+      log(`[shutdown] Token file removal failed: ${getErrorMessage(err)}`);
+    }
+  }
+  daemonToken = null;
 
   log('[daemon] Shutdown complete');
   process.exit(0);

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -252,10 +252,7 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
   // Auth token check — skip for health/status/version (needed for discovery)
   const pathname = reqUrl.pathname.replace(/^\/v1/, '');
   const isPublicEndpoint =
-    pathname === '/health' ||
-    pathname === '/api/status' ||
-    pathname === '/api/version' ||
-    pathname === '/api/health';
+    pathname === '/health' || pathname === '/api/status' || pathname === '/api/version';
   if (daemonToken && !isPublicEndpoint) {
     const authHeader = req.headers.authorization;
     const providedToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
@@ -891,7 +888,7 @@ function checkShutdown(): void {
     log(`[daemon] No more sessions and no pending work, scheduling shutdown`);
     setTimeout(() => {
       if (sessionManager?.canShutdown()) {
-        shutdownDaemon();
+        shutdownDaemon().catch((err) => log(`[daemon] shutdown failed: ${err}`));
       }
     }, 5000);
   }
@@ -904,7 +901,7 @@ function scheduleMaxUptimeGuard(logFn: (msg: string) => void): void {
     const uptime = Date.now() - state.startedAt;
     if (uptime > MAX_IDLE_UPTIME_MS) {
       logFn(`[daemon] Max idle uptime exceeded (${Math.round(uptime / 3600_000)}h), shutting down`);
-      shutdownDaemon();
+      shutdownDaemon().catch((err) => logFn(`[daemon] shutdown failed: ${err}`));
     }
   }, 3600_000); // Check every hour
   maxUptimeTimer.unref();

--- a/src/lib/db/hybrid-search.ts
+++ b/src/lib/db/hybrid-search.ts
@@ -299,14 +299,22 @@ export function hybridSearchCode(
          FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
       )
       .all(...docIds) as CodeRow[];
-    return rows.map((row) => ({
-      file_path: row.file_path,
-      content: row.content,
-      start_line: row.start_line,
-      end_line: row.end_line,
-      similarity: bm25Map.get(row.id) ?? 0,
-      bm25Score: bm25Map.get(row.id),
-    }));
+    // Preserve BM25 ranking — IN (...) returns rows in nondeterministic order
+    const rowById = new Map(rows.map((r) => [r.id, r]));
+    return docIds
+      .map((id) => {
+        const row = rowById.get(id);
+        if (!row) return null;
+        return {
+          file_path: row.file_path,
+          content: row.content,
+          start_line: row.start_line,
+          end_line: row.end_line,
+          similarity: bm25Map.get(row.id) ?? 0,
+          bm25Score: bm25Map.get(row.id),
+        };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
   }
 
   const { combined, rowMap, bm25Map, vectorMap } = pipeline;
@@ -470,14 +478,21 @@ export function hybridSearchDocs(
          FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
       )
       .all(...docIds) as DocRow[];
-    return rows.map((row) => ({
-      file_path: row.file_path,
-      content: row.content,
-      start_line: row.start_line,
-      end_line: row.end_line,
-      similarity: bm25Map.get(row.id) ?? 0,
-      bm25Score: bm25Map.get(row.id),
-    }));
+    const rowById = new Map(rows.map((r) => [r.id, r]));
+    return docIds
+      .map((id) => {
+        const row = rowById.get(id);
+        if (!row) return null;
+        return {
+          file_path: row.file_path,
+          content: row.content,
+          start_line: row.start_line,
+          end_line: row.end_line,
+          similarity: bm25Map.get(row.id) ?? 0,
+          bm25Score: bm25Map.get(row.id),
+        };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
   }
 
   if (pipeline.combined.length === 0) return [];
@@ -597,21 +612,28 @@ export function hybridSearchMemories(
          FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
       )
       .all(...docIds) as MemoryRow[];
-    return rows.map((row) => ({
-      id: row.id,
-      content: row.content,
-      tags: parseTags(row.tags),
-      source: row.source,
-      type: parseMemoryType(row.type),
-      created_at: row.created_at,
-      similarity: bm25Map.get(row.id) ?? 0,
-      bm25Score: bm25Map.get(row.id),
-      last_accessed: row.last_accessed,
-      access_count: row.access_count,
-      valid_from: row.valid_from,
-      valid_until: row.valid_until,
-      quality_score: row.quality_score,
-    }));
+    const rowById = new Map(rows.map((r) => [r.id, r]));
+    return docIds
+      .map((id) => {
+        const row = rowById.get(id);
+        if (!row) return null;
+        return {
+          id: row.id,
+          content: row.content,
+          tags: parseTags(row.tags),
+          source: row.source,
+          type: parseMemoryType(row.type),
+          created_at: row.created_at,
+          similarity: bm25Map.get(row.id) ?? 0,
+          bm25Score: bm25Map.get(row.id),
+          last_accessed: row.last_accessed,
+          access_count: row.access_count,
+          valid_from: row.valid_from,
+          valid_until: row.valid_until,
+          quality_score: row.quality_score,
+        };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
   }
 
   if (pipeline.combined.length === 0) return [];
@@ -853,8 +875,11 @@ export function hybridSearchGlobalMemories(
       params.push(since.toISOString());
     }
     const rows = database.prepare(sql).all(...params) as GlobalMemRow[];
+    const rowById = new Map(rows.map((r) => [r.id, r]));
     const results: HybridGlobalMemoryResult[] = [];
-    for (const row of rows) {
+    for (const id of docIds) {
+      const row = rowById.get(id);
+      if (!row) continue;
       const rowTags: string[] = parseTags(row.tags);
       if (tags && tags.length > 0) {
         const hasMatchingTag = tags.some((t) =>

--- a/src/lib/db/hybrid-search.ts
+++ b/src/lib/db/hybrid-search.ts
@@ -438,10 +438,15 @@ export function hybridSearchDocs(
         )
         .all(...docIds) as DocRow[];
     },
-    loadBruteForceRows: () =>
-      cachedPrepare(
+    loadBruteForceRows: () => {
+      const { count } = cachedPrepare(
+        "SELECT COUNT(*) as count FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL"
+      ).get() as { count: number };
+      if (count > BRUTE_FORCE_MAX_ROWS) return null;
+      return cachedPrepare(
         "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
-      ).all(BRUTE_FORCE_MAX_ROWS) as (DocRow & { embedding: Buffer })[],
+      ).all(BRUTE_FORCE_MAX_ROWS) as (DocRow & { embedding: Buffer })[];
+    },
     fetchMissingRows: (ids) => {
       const placeholders = ids.map(() => '?').join(',');
       return database
@@ -453,7 +458,29 @@ export function hybridSearchDocs(
     },
   });
 
-  if (!pipeline || pipeline.combined.length === 0) return [];
+  // BM25-only fallback when too many docs for brute-force
+  if (pipeline === null) {
+    const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
+    const docIds = bm25Results.slice(0, limit).map((r) => r.docId);
+    if (docIds.length === 0) return [];
+    const placeholders = docIds.map(() => '?').join(',');
+    const rows = database
+      .prepare(
+        `SELECT id, file_path, content, start_line, end_line
+         FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
+      )
+      .all(...docIds) as DocRow[];
+    return rows.map((row) => ({
+      file_path: row.file_path,
+      content: row.content,
+      start_line: row.start_line,
+      end_line: row.end_line,
+      similarity: bm25Map.get(row.id) ?? 0,
+      bm25Score: bm25Map.get(row.id),
+    }));
+  }
+
+  if (pipeline.combined.length === 0) return [];
 
   const { combined, rowMap, bm25Map, vectorMap } = pipeline;
   const results: HybridSearchResult[] = [];
@@ -701,11 +728,13 @@ export function hybridSearchGlobalMemories(
   if (bm25Raw.length > 0) {
     const bm25Ids = bm25Raw.map((r) => r.docId);
     const placeholders = bm25Ids.map(() => '?').join(',');
-    const latestRows = database
-      .prepare(
-        `SELECT id FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
-      )
-      .all(...bm25Ids) as Array<{ id: number }>;
+    let filterSql = `SELECT id FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
+    const filterParams: any[] = [...bm25Ids];
+    if (since) {
+      filterSql += ' AND created_at >= ?';
+      filterParams.push(since.toISOString());
+    }
+    const latestRows = database.prepare(filterSql).all(...filterParams) as Array<{ id: number }>;
     const latestSet = new Set(latestRows.map((r) => r.id));
     bm25Results = bm25Raw.filter((r) => latestSet.has(r.docId));
   }
@@ -753,17 +782,20 @@ export function hybridSearchGlobalMemories(
         sql += ' AND created_at >= ?';
         params.push(since.toISOString());
       }
-      sql += ` LIMIT ${BRUTE_FORCE_MAX_ROWS}`;
+      sql += ' LIMIT ?';
+      params.push(BRUTE_FORCE_MAX_ROWS);
       return database.prepare(sql).all(...params) as (GlobalMemRow & { embedding: Buffer })[];
     },
     fetchMissingRows: (ids) => {
       const placeholders = ids.map(() => '?').join(',');
-      return database
-        .prepare(
-          `SELECT id, content, tags, source, project, type, created_at
-           FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
-        )
-        .all(...ids) as GlobalMemRow[];
+      let sql = `SELECT id, content, tags, source, project, type, created_at
+           FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
+      const params: any[] = [...ids];
+      if (since) {
+        sql += ' AND created_at >= ?';
+        params.push(since.toISOString());
+      }
+      return database.prepare(sql).all(...params) as GlobalMemRow[];
     },
   });
 

--- a/src/lib/db/hybrid-search.ts
+++ b/src/lib/db/hybrid-search.ts
@@ -269,11 +269,11 @@ export function hybridSearchCode(
     },
     loadBruteForceRows: () => {
       const { count } = cachedPrepare(
-        "SELECT COUNT(*) as count FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL"
+        "SELECT COUNT(*) as count FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL AND embedding IS NOT NULL"
       ).get() as { count: number };
       if (count > BRUTE_FORCE_MAX_ROWS) return null;
       return cachedPrepare(
-        "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
+        "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL AND embedding IS NOT NULL LIMIT ?"
       ).all(BRUTE_FORCE_MAX_ROWS) as (CodeRow & { embedding: Buffer })[];
     },
     fetchMissingRows: (ids) => {
@@ -290,7 +290,9 @@ export function hybridSearchCode(
   // BM25-only fallback when too many docs for brute-force
   if (pipeline === null) {
     const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
-    const docIds = bm25Results.slice(0, limit).map((r) => r.docId);
+    // Fetch extra candidates since regex/symbolType filtering may remove some
+    const candidateCount = filters?.regex || filters?.symbolType ? limit * 3 : limit;
+    const docIds = bm25Results.slice(0, candidateCount).map((r) => r.docId);
     if (docIds.length === 0) return [];
     const placeholders = docIds.map(() => '?').join(',');
     const rows = database
@@ -299,22 +301,59 @@ export function hybridSearchCode(
          FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
       )
       .all(...docIds) as CodeRow[];
-    // Preserve BM25 ranking — IN (...) returns rows in nondeterministic order
+
+    // Symbol lookup for filtering and boosting
+    const symbolMap = new Map<number, { symbol_name: string | null; symbol_type: string | null }>();
+    if (docIds.length > 0) {
+      const symRows = database
+        .prepare(`SELECT id, symbol_name, symbol_type FROM documents WHERE id IN (${placeholders})`)
+        .all(...docIds) as Array<{
+        id: number;
+        symbol_name: string | null;
+        symbol_type: string | null;
+      }>;
+      for (const sr of symRows) {
+        symbolMap.set(sr.id, { symbol_name: sr.symbol_name, symbol_type: sr.symbol_type });
+      }
+    }
+
+    // Regex filter (same validation as normal path)
+    let regexFilter: RegExp | null = null;
+    if (filters?.regex && filters.regex.length <= 500) {
+      const hasNestedQuantifiers = /(\+|\*|\{)\s*\)(\+|\*|\?)|\(\?[^)]*(\+|\*)\)(\+|\*|\?)/.test(
+        filters.regex
+      );
+      if (!hasNestedQuantifiers) {
+        try {
+          regexFilter = new RegExp(filters.regex, 'i');
+        } catch {
+          logWarn('hybrid-search', 'Invalid regex filter in BM25 fallback, skipping');
+        }
+      }
+    }
+
+    // Preserve BM25 ranking with symbol/regex filtering
     const rowById = new Map(rows.map((r) => [r.id, r]));
-    return docIds
-      .map((id) => {
-        const row = rowById.get(id);
-        if (!row) return null;
-        return {
-          file_path: row.file_path,
-          content: row.content,
-          start_line: row.start_line,
-          end_line: row.end_line,
-          similarity: bm25Map.get(row.id) ?? 0,
-          bm25Score: bm25Map.get(row.id),
-        };
-      })
-      .filter((r): r is NonNullable<typeof r> => r !== null);
+    const results: HybridSearchResult[] = [];
+    for (const id of docIds) {
+      if (results.length >= limit) break;
+      const row = rowById.get(id);
+      if (!row) continue;
+      const sym = symbolMap.get(id);
+      if (filters?.symbolType && sym?.symbol_type !== filters.symbolType) continue;
+      if (regexFilter && !regexFilter.test(row.content)) continue;
+      results.push({
+        file_path: row.file_path,
+        content: row.content,
+        start_line: row.start_line,
+        end_line: row.end_line,
+        similarity: bm25Map.get(id) ?? 0,
+        bm25Score: bm25Map.get(id),
+        symbol_name: sym?.symbol_name ?? undefined,
+        symbol_type: sym?.symbol_type ?? undefined,
+      });
+    }
+    return results;
   }
 
   const { combined, rowMap, bm25Map, vectorMap } = pipeline;
@@ -448,11 +487,11 @@ export function hybridSearchDocs(
     },
     loadBruteForceRows: () => {
       const { count } = cachedPrepare(
-        "SELECT COUNT(*) as count FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL"
+        "SELECT COUNT(*) as count FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL AND embedding IS NOT NULL"
       ).get() as { count: number };
       if (count > BRUTE_FORCE_MAX_ROWS) return null;
       return cachedPrepare(
-        "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
+        "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL AND embedding IS NOT NULL LIMIT ?"
       ).all(BRUTE_FORCE_MAX_ROWS) as (DocRow & { embedding: Buffer })[];
     },
     fetchMissingRows: (ids) => {

--- a/src/lib/db/hybrid-search.ts
+++ b/src/lib/db/hybrid-search.ts
@@ -156,19 +156,19 @@ function runHybridPipeline<TRow extends { id: number }>(
   if (vectorResults.length === 0) {
     const bruteForceRows = loadBruteForceRows();
     if (bruteForceRows === null) return null;
-    if (bruteForceRows.length === 0) {
-      return { combined: [], rowMap, bm25Map: new Map(), vectorMap: new Map() };
-    }
 
-    rowMap = new Map(bruteForceRows.map((r) => [r.id, r]));
-    for (const row of bruteForceRows) {
-      const embedding = bufferToFloatArray(row.embedding);
-      const similarity = cosineSimilarity(queryEmbedding, embedding);
-      if (similarity >= threshold) {
-        vectorResults.push({ docId: row.id, score: similarity });
+    if (bruteForceRows.length > 0) {
+      rowMap = new Map(bruteForceRows.map((r) => [r.id, r]));
+      for (const row of bruteForceRows) {
+        const embedding = bufferToFloatArray(row.embedding);
+        const similarity = cosineSimilarity(queryEmbedding, embedding);
+        if (similarity >= threshold) {
+          vectorResults.push({ docId: row.id, score: similarity });
+        }
       }
+      vectorResults.sort((a, b) => b.score - a.score);
     }
-    vectorResults.sort((a, b) => b.score - a.score);
+    // Empty bruteForceRows: let RRF combine BM25 with empty vector results
   }
 
   const topVectorResults = vectorResults.slice(0, limit * 3);
@@ -332,7 +332,14 @@ export function hybridSearchCode(
       }
     }
 
-    // Preserve BM25 ranking with symbol/regex filtering
+    // Symbol name boost tokens (same logic as normal path)
+    const queryTokens = query
+      .toLowerCase()
+      .trim()
+      .split(/[\s,]+/)
+      .filter(Boolean);
+
+    // Preserve BM25 ranking with symbol/regex filtering and boost
     const rowById = new Map(rows.map((r) => [r.id, r]));
     const results: HybridSearchResult[] = [];
     for (const id of docIds) {
@@ -342,12 +349,27 @@ export function hybridSearchCode(
       const sym = symbolMap.get(id);
       if (filters?.symbolType && sym?.symbol_type !== filters.symbolType) continue;
       if (regexFilter && !regexFilter.test(row.content)) continue;
+
+      let score = bm25Map.get(id) ?? 0;
+      if (sym?.symbol_name) {
+        const symLower = sym.symbol_name.toLowerCase();
+        for (const token of queryTokens) {
+          if (symLower === token) {
+            score += 0.15;
+            break;
+          } else if (symLower.includes(token) || token.includes(symLower)) {
+            score += 0.08;
+            break;
+          }
+        }
+      }
+
       results.push({
         file_path: row.file_path,
         content: row.content,
         start_line: row.start_line,
         end_line: row.end_line,
-        similarity: bm25Map.get(id) ?? 0,
+        similarity: Math.min(score, 1.0),
         bm25Score: bm25Map.get(id),
         symbol_name: sym?.symbol_name ?? undefined,
         symbol_type: sym?.symbol_type ?? undefined,

--- a/src/lib/db/hybrid-search.ts
+++ b/src/lib/db/hybrid-search.ts
@@ -43,12 +43,10 @@ export interface HybridMemoryResult {
   similarity: number;
   bm25Score?: number;
   vectorScore?: number;
-  // Temporal fields
   last_accessed?: string | null;
   access_count?: number;
   valid_from?: string | null;
   valid_until?: string | null;
-  // Quality
   quality_score?: number | null;
 }
 
@@ -67,10 +65,6 @@ export interface HybridGlobalMemoryResult {
   isGlobal: true;
 }
 
-// ============================================================================
-// Hybrid Search Functions
-// ============================================================================
-
 export interface CodeSearchFilters {
   /** Filter results to only those matching this regex against content */
   regex?: string;
@@ -78,88 +72,67 @@ export interface CodeSearchFilters {
   symbolType?: string;
 }
 
+// ============================================================================
+// Shared Hybrid Search Pipeline
+// ============================================================================
+
+interface HybridPipelineConfig<TRow extends { id: number }> {
+  queryEmbedding: number[];
+  bm25Results: { docId: number; score: number }[];
+  limit: number;
+  threshold: number;
+  alpha: number;
+  rrfK?: number;
+  prepare: typeof cachedPrepare;
+  logContext: string;
+  vecQuery: string;
+  filterVecRows: (docIds: number[]) => TRow[];
+  loadBruteForceRows: () => (TRow & { embedding: Buffer })[] | null;
+  fetchMissingRows: (ids: number[]) => TRow[];
+}
+
+interface HybridPipelineResult<TRow> {
+  combined: { docId: number; score: number }[];
+  rowMap: Map<number, TRow>;
+  bm25Map: Map<number, number>;
+  vectorMap: Map<number, number>;
+}
+
 /**
- * Hybrid search combining BM25 and vector similarity.
- * Uses sqlite-vec for fast KNN vector search when available.
- *
- * @param query - Search query string
- * @param queryEmbedding - Query embedding vector
- * @param limit - Max results
- * @param threshold - Min similarity threshold
- * @param alpha - Weight: 0=pure BM25, 1=pure vector, 0.5=equal (default: 0.5)
- * @param filters - Optional regex/symbol_type filters
+ * Shared pipeline for BM25 + vector hybrid search with RRF fusion.
+ * Returns null when brute-force is skipped (caller handles BM25-only fallback).
  */
-export function hybridSearchCode(
-  query: string,
-  queryEmbedding: number[],
-  limit: number = 5,
-  threshold: number = 0.25,
-  alpha: number = 0.5,
-  filters?: CodeSearchFilters,
-  rrfK?: number
-): HybridSearchResult[] {
-  const database = getDb();
+function runHybridPipeline<TRow extends { id: number }>(
+  config: HybridPipelineConfig<TRow>
+): HybridPipelineResult<TRow> | null {
+  const {
+    queryEmbedding,
+    bm25Results,
+    limit,
+    threshold,
+    alpha,
+    rrfK,
+    prepare,
+    logContext,
+    vecQuery,
+    filterVecRows,
+    loadBruteForceRows,
+    fetchMissingRows,
+  } = config;
 
-  // 1. BM25 search with Ronin-style segmentation for flatcase queries
-  const bm25Index = getCodeBm25Index();
-
-  // Enhance query with segmented tokens if it looks like flatcase
-  let enhancedQuery = query;
-  const totalTokens = getTotalTokenCount();
-  if (totalTokens > 0) {
-    const tokens = bm25.tokenizeCodeWithSegmentation(
-      query,
-      (token) => getTokenFrequency(token),
-      totalTokens
-    );
-    if (tokens.length > query.split(/\s+/).length) {
-      enhancedQuery = tokens.join(' ');
-    }
-  }
-
-  const bm25Results = bm25.search(enhancedQuery, bm25Index, 'code', limit * 3);
-
-  // 2. Vector search - try sqlite-vec first
   let vectorResults: { docId: number; score: number }[] = [];
-  let rowMap: Map<
-    number,
-    { id: number; file_path: string; content: string; start_line: number; end_line: number }
-  > = new Map();
+  let rowMap = new Map<number, TRow>();
 
   if (sqliteVecAvailable) {
     try {
-      const candidateLimit = limit * 5;
       const queryBuffer = floatArrayToBuffer(queryEmbedding);
-
-      const vecResults = cachedPrepare(`
-        SELECT m.doc_id, v.distance
-        FROM vec_documents v
-        JOIN vec_documents_map m ON m.vec_rowid = v.rowid
-        WHERE v.embedding MATCH ?
-          AND k = ?
-        ORDER BY v.distance
-      `).all(queryBuffer, candidateLimit) as Array<{ doc_id: number; distance: number }>;
+      const vecResults = prepare(vecQuery).all(queryBuffer, limit * 5) as Array<{
+        doc_id: number;
+        distance: number;
+      }>;
 
       if (vecResults.length > 0) {
-        // Filter to only code documents
-        const docIds = vecResults.map((r) => r.doc_id);
-        const placeholders = docIds.map(() => '?').join(',');
-        const rows = database
-          .prepare(
-            `
-          SELECT id, file_path, content, start_line, end_line
-          FROM documents
-          WHERE id IN (${placeholders}) AND file_path LIKE 'code:%' AND superseded_at IS NULL
-        `
-          )
-          .all(...docIds) as Array<{
-          id: number;
-          file_path: string;
-          content: string;
-          start_line: number;
-          end_line: number;
-        }>;
-
+        const rows = filterVecRows(vecResults.map((r) => r.doc_id));
         rowMap = new Map(rows.map((r) => [r.id, r]));
         const distanceMap = new Map(vecResults.map((r) => [r.doc_id, r.distance]));
 
@@ -173,66 +146,22 @@ export function hybridSearchCode(
         vectorResults.sort((a, b) => b.score - a.score);
       }
     } catch (error) {
-      logWarn('hybrid-search', 'Code vector search failed, using fallback strategy', {
+      logWarn('hybrid-search', `${logContext} vector search failed, using fallback strategy`, {
         error: error instanceof Error ? error.message : String(error),
       });
-      // Fall through to brute-force
       vectorResults = [];
     }
   }
 
-  // Brute-force fallback for vector search (sqlite-vec unavailable or returned 0)
   if (vectorResults.length === 0) {
-    const { count } = cachedPrepare(
-      "SELECT COUNT(*) as count FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL"
-    ).get() as { count: number };
-
-    if (count > BRUTE_FORCE_MAX_ROWS) {
-      // Too many docs for brute-force — return BM25-only results
-      const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
-      const docIds = bm25Results.slice(0, limit).map((r) => r.docId);
-      if (docIds.length === 0) return [];
-      const placeholders = docIds.map(() => '?').join(',');
-      const fallbackRows = database
-        .prepare(
-          `
-        SELECT id, file_path, content, start_line, end_line
-        FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL
-      `
-        )
-        .all(...docIds) as Array<{
-        id: number;
-        file_path: string;
-        content: string;
-        start_line: number;
-        end_line: number;
-      }>;
-      return fallbackRows.map((row) => ({
-        file_path: row.file_path,
-        content: row.content,
-        start_line: row.start_line,
-        end_line: row.end_line,
-        similarity: bm25Map.get(row.id) ?? 0,
-        bm25Score: bm25Map.get(row.id),
-      }));
+    const bruteForceRows = loadBruteForceRows();
+    if (bruteForceRows === null) return null;
+    if (bruteForceRows.length === 0) {
+      return { combined: [], rowMap, bm25Map: new Map(), vectorMap: new Map() };
     }
 
-    const rows = cachedPrepare(
-      "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
-    ).all(BRUTE_FORCE_MAX_ROWS) as Array<{
-      id: number;
-      file_path: string;
-      content: string;
-      start_line: number;
-      end_line: number;
-      embedding: Buffer;
-    }>;
-
-    if (rows.length === 0) return [];
-
-    rowMap = new Map(rows.map((r) => [r.id, r]));
-
-    for (const row of rows) {
+    rowMap = new Map(bruteForceRows.map((r) => [r.id, r]));
+    for (const row of bruteForceRows) {
       const embedding = bufferToFloatArray(row.embedding);
       const similarity = cosineSimilarity(queryEmbedding, embedding);
       if (similarity >= threshold) {
@@ -243,49 +172,153 @@ export function hybridSearchCode(
   }
 
   const topVectorResults = vectorResults.slice(0, limit * 3);
-
-  // 3. Combine using RRF
   const combined = bm25.reciprocalRankFusion(bm25Results, topVectorResults, alpha, limit, rrfK);
 
-  // 4. Ensure we have all needed rows in the map (for BM25 results that might not be in vec results)
   if (combined.length > 0) {
     const missingIds = combined.filter((c) => !rowMap.has(c.docId)).map((c) => c.docId);
     if (missingIds.length > 0) {
-      const placeholders = missingIds.map(() => '?').join(',');
-      const missingRows = getDb()
-        .prepare(
-          `
-        SELECT id, file_path, content, start_line, end_line
-        FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL
-      `
-        )
-        .all(...missingIds) as Array<{
-        id: number;
-        file_path: string;
-        content: string;
-        start_line: number;
-        end_line: number;
-      }>;
-      for (const row of missingRows) {
+      for (const row of fetchMissingRows(missingIds)) {
         rowMap.set(row.id, row);
       }
     }
   }
 
-  const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
-  const vectorMap = new Map(vectorResults.map((r) => [r.docId, r.score]));
+  return {
+    combined,
+    rowMap,
+    bm25Map: new Map(bm25Results.map((r) => [r.docId, r.score])),
+    vectorMap: new Map(vectorResults.map((r) => [r.docId, r.score])),
+  };
+}
 
-  // 5. Symbol name match boost — fetch AST metadata for result set
+// ============================================================================
+// Hybrid Search Functions
+// ============================================================================
+
+const VEC_DOCUMENTS_QUERY = `
+  SELECT m.doc_id, v.distance
+  FROM vec_documents v
+  JOIN vec_documents_map m ON m.vec_rowid = v.rowid
+  WHERE v.embedding MATCH ? AND k = ?
+  ORDER BY v.distance`;
+
+const VEC_MEMORIES_QUERY = `
+  SELECT m.memory_id AS doc_id, v.distance
+  FROM vec_memories v
+  JOIN vec_memories_map m ON m.vec_rowid = v.rowid
+  WHERE v.embedding MATCH ? AND k = ?
+  ORDER BY v.distance`;
+
+/**
+ * Hybrid search combining BM25 and vector similarity.
+ * Uses sqlite-vec for fast KNN vector search when available.
+ */
+export function hybridSearchCode(
+  query: string,
+  queryEmbedding: number[],
+  limit: number = 5,
+  threshold: number = 0.25,
+  alpha: number = 0.5,
+  filters?: CodeSearchFilters,
+  rrfK?: number
+): HybridSearchResult[] {
+  const database = getDb();
+
+  const bm25Index = getCodeBm25Index();
+  let enhancedQuery = query;
+  const totalTokens = getTotalTokenCount();
+  if (totalTokens > 0) {
+    const tokens = bm25.tokenizeCodeWithSegmentation(
+      query,
+      (token) => getTokenFrequency(token),
+      totalTokens
+    );
+    if (tokens.length > query.split(/\s+/).length) {
+      enhancedQuery = tokens.join(' ');
+    }
+  }
+  const bm25Results = bm25.search(enhancedQuery, bm25Index, 'code', limit * 3);
+
+  type CodeRow = {
+    id: number;
+    file_path: string;
+    content: string;
+    start_line: number;
+    end_line: number;
+  };
+
+  const pipeline = runHybridPipeline<CodeRow>({
+    queryEmbedding,
+    bm25Results,
+    limit,
+    threshold,
+    alpha,
+    rrfK,
+    prepare: cachedPrepare,
+    logContext: 'Code',
+    vecQuery: VEC_DOCUMENTS_QUERY,
+    filterVecRows: (docIds) => {
+      const placeholders = docIds.map(() => '?').join(',');
+      return database
+        .prepare(
+          `SELECT id, file_path, content, start_line, end_line
+           FROM documents
+           WHERE id IN (${placeholders}) AND file_path LIKE 'code:%' AND superseded_at IS NULL`
+        )
+        .all(...docIds) as CodeRow[];
+    },
+    loadBruteForceRows: () => {
+      const { count } = cachedPrepare(
+        "SELECT COUNT(*) as count FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL"
+      ).get() as { count: number };
+      if (count > BRUTE_FORCE_MAX_ROWS) return null;
+      return cachedPrepare(
+        "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
+      ).all(BRUTE_FORCE_MAX_ROWS) as (CodeRow & { embedding: Buffer })[];
+    },
+    fetchMissingRows: (ids) => {
+      const placeholders = ids.map(() => '?').join(',');
+      return database
+        .prepare(
+          `SELECT id, file_path, content, start_line, end_line
+           FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
+        )
+        .all(...ids) as CodeRow[];
+    },
+  });
+
+  // BM25-only fallback when too many docs for brute-force
+  if (pipeline === null) {
+    const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
+    const docIds = bm25Results.slice(0, limit).map((r) => r.docId);
+    if (docIds.length === 0) return [];
+    const placeholders = docIds.map(() => '?').join(',');
+    const rows = database
+      .prepare(
+        `SELECT id, file_path, content, start_line, end_line
+         FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
+      )
+      .all(...docIds) as CodeRow[];
+    return rows.map((row) => ({
+      file_path: row.file_path,
+      content: row.content,
+      start_line: row.start_line,
+      end_line: row.end_line,
+      similarity: bm25Map.get(row.id) ?? 0,
+      bm25Score: bm25Map.get(row.id),
+    }));
+  }
+
+  const { combined, rowMap, bm25Map, vectorMap } = pipeline;
+  if (combined.length === 0) return [];
+
+  // Symbol name match boost
   const resultDocIds = combined.map((c) => c.docId);
   const symbolMap = new Map<number, { symbol_name: string | null; symbol_type: string | null }>();
   if (resultDocIds.length > 0) {
     const placeholders = resultDocIds.map(() => '?').join(',');
     const symbolRows = database
-      .prepare(
-        `
-      SELECT id, symbol_name, symbol_type FROM documents WHERE id IN (${placeholders})
-    `
-      )
+      .prepare(`SELECT id, symbol_name, symbol_type FROM documents WHERE id IN (${placeholders})`)
       .all(...resultDocIds) as Array<{
       id: number;
       symbol_name: string | null;
@@ -302,10 +335,8 @@ export function hybridSearchCode(
     .split(/[\s,]+/)
     .filter(Boolean);
 
-  // Pre-compile regex filter if provided (limit length and reject ReDoS-prone patterns)
   let regexFilter: RegExp | null = null;
   if (filters?.regex && filters.regex.length <= 500) {
-    // Reject patterns with nested quantifiers that cause catastrophic backtracking
     const hasNestedQuantifiers = /(\+|\*|\{)\s*\)(\+|\*|\?)|\(\?[^)]*(\+|\*)\)(\+|\*|\?)/.test(
       filters.regex
     );
@@ -330,24 +361,19 @@ export function hybridSearchCode(
     const row = rowMap.get(c.docId);
     if (!row) continue;
 
-    // Apply symbol_type filter
     const sym = symbolMap.get(c.docId);
     if (filters?.symbolType && sym?.symbol_type !== filters.symbolType) continue;
-
-    // Apply regex filter against content
     if (regexFilter && !regexFilter.test(row.content)) continue;
 
     let score = c.score;
-
-    // Boost results where symbol_name matches query tokens
     if (sym?.symbol_name) {
       const symLower = sym.symbol_name.toLowerCase();
       for (const token of queryTokens) {
         if (symLower === token) {
-          score += 0.15; // Exact symbol name match
+          score += 0.15;
           break;
         } else if (symLower.includes(token) || token.includes(symLower)) {
-          score += 0.08; // Partial symbol name match
+          score += 0.08;
           break;
         }
       }
@@ -366,7 +392,6 @@ export function hybridSearchCode(
     });
   }
 
-  // Re-sort by boosted score
   results.sort((a, b) => b.similarity - a.similarity);
   return results;
 }
@@ -383,127 +408,54 @@ export function hybridSearchDocs(
   rrfK?: number
 ): HybridSearchResult[] {
   const database = getDb();
+  const bm25Results = bm25.search(query, getDocsBm25Index(), 'docs', limit * 3);
 
-  // 1. BM25 search with docs tokenizer (stemming)
-  const bm25Index = getDocsBm25Index();
-  const bm25Results = bm25.search(query, bm25Index, 'docs', limit * 3);
+  type DocRow = {
+    id: number;
+    file_path: string;
+    content: string;
+    start_line: number;
+    end_line: number;
+  };
 
-  // 2. Vector search — try sqlite-vec first, fall back to brute-force
-  let vectorResults: { docId: number; score: number }[] = [];
-  let rowMap: Map<
-    number,
-    { id: number; file_path: string; content: string; start_line: number; end_line: number }
-  > = new Map();
-
-  if (sqliteVecAvailable) {
-    try {
-      const candidateLimit = limit * 5;
-      const queryBuffer = floatArrayToBuffer(queryEmbedding);
-      const vecResults = cachedPrepare(`
-        SELECT m.doc_id, v.distance
-        FROM vec_documents v
-        JOIN vec_documents_map m ON m.vec_rowid = v.rowid
-        WHERE v.embedding MATCH ?
-          AND k = ?
-        ORDER BY v.distance
-      `).all(queryBuffer, candidateLimit) as Array<{ doc_id: number; distance: number }>;
-
-      if (vecResults.length > 0) {
-        const docIds = vecResults.map((r) => r.doc_id);
-        const placeholders = docIds.map(() => '?').join(',');
-        const rows = database
-          .prepare(
-            `
-          SELECT id, file_path, content, start_line, end_line
-          FROM documents
-          WHERE id IN (${placeholders}) AND file_path NOT LIKE 'code:%' AND superseded_at IS NULL
-        `
-          )
-          .all(...docIds) as Array<{
-          id: number;
-          file_path: string;
-          content: string;
-          start_line: number;
-          end_line: number;
-        }>;
-
-        rowMap = new Map(rows.map((r) => [r.id, r]));
-        const distanceMap = new Map(vecResults.map((r) => [r.doc_id, r.distance]));
-        for (const row of rows) {
-          const distance = distanceMap.get(row.id) ?? 1;
-          const similarity = 1 - distance;
-          if (similarity >= threshold) {
-            vectorResults.push({ docId: row.id, score: similarity });
-          }
-        }
-        vectorResults.sort((a, b) => b.score - a.score);
-      }
-    } catch (error) {
-      logWarn('hybrid-search', 'Docs vector search failed, using fallback strategy', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      vectorResults = [];
-    }
-  }
-
-  // Brute-force fallback with safety limit
-  if (vectorResults.length === 0) {
-    const rows = cachedPrepare(
-      "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
-    ).all(BRUTE_FORCE_MAX_ROWS) as Array<{
-      id: number;
-      file_path: string;
-      content: string;
-      start_line: number;
-      end_line: number;
-      embedding: Buffer;
-    }>;
-
-    if (rows.length === 0) return [];
-    rowMap = new Map(rows.map((r) => [r.id, r]));
-
-    for (const row of rows) {
-      const embedding = bufferToFloatArray(row.embedding);
-      const similarity = cosineSimilarity(queryEmbedding, embedding);
-      if (similarity >= threshold) {
-        vectorResults.push({ docId: row.id, score: similarity });
-      }
-    }
-    vectorResults.sort((a, b) => b.score - a.score);
-  }
-  const topVectorResults = vectorResults.slice(0, limit * 3);
-
-  // 3. Combine using RRF
-  const combined = bm25.reciprocalRankFusion(bm25Results, topVectorResults, alpha, limit, rrfK);
-
-  // 4. Ensure we have all needed rows (BM25 results may not be in vec results)
-  if (combined.length > 0) {
-    const missingIds = combined.filter((c) => !rowMap.has(c.docId)).map((c) => c.docId);
-    if (missingIds.length > 0) {
-      const placeholders = missingIds.map(() => '?').join(',');
-      const missingRows = database
+  const pipeline = runHybridPipeline<DocRow>({
+    queryEmbedding,
+    bm25Results,
+    limit,
+    threshold,
+    alpha,
+    rrfK,
+    prepare: cachedPrepare,
+    logContext: 'Docs',
+    vecQuery: VEC_DOCUMENTS_QUERY,
+    filterVecRows: (docIds) => {
+      const placeholders = docIds.map(() => '?').join(',');
+      return database
         .prepare(
-          `
-        SELECT id, file_path, content, start_line, end_line
-        FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL
-      `
+          `SELECT id, file_path, content, start_line, end_line
+           FROM documents
+           WHERE id IN (${placeholders}) AND file_path NOT LIKE 'code:%' AND superseded_at IS NULL`
         )
-        .all(...missingIds) as Array<{
-        id: number;
-        file_path: string;
-        content: string;
-        start_line: number;
-        end_line: number;
-      }>;
-      for (const row of missingRows) {
-        rowMap.set(row.id, row);
-      }
-    }
-  }
+        .all(...docIds) as DocRow[];
+    },
+    loadBruteForceRows: () =>
+      cachedPrepare(
+        "SELECT id, file_path, content, start_line, end_line, embedding FROM documents WHERE file_path NOT LIKE 'code:%' AND superseded_at IS NULL LIMIT ?"
+      ).all(BRUTE_FORCE_MAX_ROWS) as (DocRow & { embedding: Buffer })[],
+    fetchMissingRows: (ids) => {
+      const placeholders = ids.map(() => '?').join(',');
+      return database
+        .prepare(
+          `SELECT id, file_path, content, start_line, end_line
+           FROM documents WHERE id IN (${placeholders}) AND superseded_at IS NULL`
+        )
+        .all(...ids) as DocRow[];
+    },
+  });
 
-  const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
-  const vectorMap = new Map(vectorResults.map((r) => [r.docId, r.score]));
+  if (!pipeline || pipeline.combined.length === 0) return [];
 
+  const { combined, rowMap, bm25Map, vectorMap } = pipeline;
   const results: HybridSearchResult[] = [];
   for (const c of combined) {
     const row = rowMap.get(c.docId);
@@ -534,10 +486,7 @@ export function hybridSearchMemories(
 ): HybridMemoryResult[] {
   const database = getDb();
 
-  // 1. BM25 search — filter out demoted (non-latest) memories before RRF
-  // so they don't consume fused slots and reduce result quality
-  const bm25Index = getMemoriesBm25Index();
-  const bm25Raw = bm25.search(query, bm25Index, 'docs', limit * 3);
+  const bm25Raw = bm25.search(query, getMemoriesBm25Index(), 'docs', limit * 3);
   let bm25Results = bm25Raw;
   if (bm25Raw.length > 0) {
     const bm25Ids = bm25Raw.map((r) => r.docId);
@@ -549,8 +498,6 @@ export function hybridSearchMemories(
     bm25Results = bm25Raw.filter((r) => latestSet.has(r.docId));
   }
 
-  // 2. Vector search — try sqlite-vec first
-  let vectorResults: { docId: number; score: number }[] = [];
   type MemoryRow = {
     id: number;
     content: string;
@@ -564,105 +511,50 @@ export function hybridSearchMemories(
     valid_until: string | null;
     quality_score: number | null;
   };
-  let rowMap: Map<number, MemoryRow> = new Map();
 
-  if (sqliteVecAvailable) {
-    try {
-      const candidateLimit = limit * 5;
-      const queryBuffer = floatArrayToBuffer(queryEmbedding);
-      const vecResults = cachedPrepare(`
-        SELECT m.memory_id AS doc_id, v.distance
-        FROM vec_memories v
-        JOIN vec_memories_map m ON m.vec_rowid = v.rowid
-        WHERE v.embedding MATCH ?
-          AND k = ?
-        ORDER BY v.distance
-      `).all(queryBuffer, candidateLimit) as Array<{ doc_id: number; distance: number }>;
-
-      if (vecResults.length > 0) {
-        const docIds = vecResults.map((r) => r.doc_id);
-        const placeholders = docIds.map(() => '?').join(',');
-        const rows = database
-          .prepare(
-            `
-          SELECT id, content, tags, source, type, created_at,
-                 last_accessed, access_count, valid_from, valid_until, quality_score
-          FROM memories
-          WHERE id IN (${placeholders})
-            AND COALESCE(is_latest, 1) = 1
-        `
-          )
-          .all(...docIds) as MemoryRow[];
-
-        rowMap = new Map(rows.map((r) => [r.id, r]));
-        const distanceMap = new Map(vecResults.map((r) => [r.doc_id, r.distance]));
-        for (const row of rows) {
-          const distance = distanceMap.get(row.id) ?? 1;
-          const similarity = 1 - distance;
-          if (similarity >= threshold) {
-            vectorResults.push({ docId: row.id, score: similarity });
-          }
-        }
-        vectorResults.sort((a, b) => b.score - a.score);
-      }
-    } catch (error) {
-      logWarn('hybrid-search', 'Memory vector search failed, using fallback strategy', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      vectorResults = [];
-    }
-  }
-
-  // Brute-force fallback with safety limit
-  if (vectorResults.length === 0) {
-    const rows = cachedPrepare(`
-      SELECT id, content, tags, source, type, created_at, embedding,
-             last_accessed, access_count, valid_from, valid_until, quality_score
-      FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1 LIMIT ?
-    `).all(BRUTE_FORCE_MAX_ROWS) as Array<MemoryRow & { embedding: Buffer }>;
-
-    if (rows.length === 0) return [];
-    rowMap = new Map(rows.map((r) => [r.id, r]));
-
-    for (const row of rows) {
-      const embedding = bufferToFloatArray(row.embedding);
-      const similarity = cosineSimilarity(queryEmbedding, embedding);
-      if (similarity >= threshold) {
-        vectorResults.push({ docId: row.id, score: similarity });
-      }
-    }
-    vectorResults.sort((a, b) => b.score - a.score);
-  }
-  const topVectorResults = vectorResults.slice(0, limit * 3);
-
-  // 3. Combine using RRF
-  const combined = bm25.reciprocalRankFusion(bm25Results, topVectorResults, alpha, limit, rrfK);
-
-  // 4. Ensure we have all needed rows
-  if (combined.length > 0) {
-    const missingIds = combined.filter((c) => !rowMap.has(c.docId)).map((c) => c.docId);
-    if (missingIds.length > 0) {
-      const placeholders = missingIds.map(() => '?').join(',');
-      const missingRows = database
+  const pipeline = runHybridPipeline<MemoryRow>({
+    queryEmbedding,
+    bm25Results,
+    limit,
+    threshold,
+    alpha,
+    rrfK,
+    prepare: cachedPrepare,
+    logContext: 'Memory',
+    vecQuery: VEC_MEMORIES_QUERY,
+    filterVecRows: (docIds) => {
+      const placeholders = docIds.map(() => '?').join(',');
+      return database
         .prepare(
-          `
-        SELECT id, content, tags, source, type, created_at,
-               last_accessed, access_count, valid_from, valid_until, quality_score
-        FROM memories
-        WHERE id IN (${placeholders})
-          AND COALESCE(is_latest, 1) = 1
-      `
+          `SELECT id, content, tags, source, type, created_at,
+                  last_accessed, access_count, valid_from, valid_until, quality_score
+           FROM memories
+           WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
         )
-        .all(...missingIds) as MemoryRow[];
-      for (const row of missingRows) {
-        rowMap.set(row.id, row);
-      }
-    }
-  }
+        .all(...docIds) as MemoryRow[];
+    },
+    loadBruteForceRows: () =>
+      cachedPrepare(
+        `SELECT id, content, tags, source, type, created_at, embedding,
+                last_accessed, access_count, valid_from, valid_until, quality_score
+         FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1 LIMIT ?`
+      ).all(BRUTE_FORCE_MAX_ROWS) as (MemoryRow & { embedding: Buffer })[],
+    fetchMissingRows: (ids) => {
+      const placeholders = ids.map(() => '?').join(',');
+      return database
+        .prepare(
+          `SELECT id, content, tags, source, type, created_at,
+                  last_accessed, access_count, valid_from, valid_until, quality_score
+           FROM memories
+           WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
+        )
+        .all(...ids) as MemoryRow[];
+    },
+  });
 
-  const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
-  const vectorMap = new Map(vectorResults.map((r) => [r.docId, r.score]));
+  if (!pipeline || pipeline.combined.length === 0) return [];
 
+  const { combined, rowMap, bm25Map, vectorMap } = pipeline;
   const results: HybridMemoryResult[] = [];
   for (const c of combined) {
     const row = rowMap.get(c.docId);
@@ -689,15 +581,6 @@ export function hybridSearchMemories(
 
 /**
  * Graph-enhanced memory search: BM25 + vector + PPR as third RRF signal.
- * Runs standard hybrid search first, then uses top results as PPR seed nodes
- * to discover graph-connected memories. Merges all three via weighted RRF.
- *
- * @param query - Search query
- * @param queryEmbedding - Query embedding vector
- * @param limit - Max results
- * @param threshold - Minimum similarity
- * @param alpha - BM25/vector balance
- * @param graphWeight - PPR signal weight in RRF (0-1, default 0.3)
  */
 export async function graphEnhancedSearchMemories(
   query: string,
@@ -708,7 +591,6 @@ export async function graphEnhancedSearchMemories(
   graphWeight: number = 0.3,
   rrfK?: number
 ): Promise<HybridMemoryResult[]> {
-  // Step 1: Standard BM25 + vector search
   const baseResults = hybridSearchMemories(
     query,
     queryEmbedding,
@@ -717,10 +599,8 @@ export async function graphEnhancedSearchMemories(
     alpha,
     rrfK
   );
-
   if (baseResults.length === 0) return baseResults;
 
-  // Step 2: Run PPR from top results as seed nodes
   let pprScores: Map<number, number>;
   try {
     const { personalizedPageRank } = await import('../graph/graphology-bridge.js');
@@ -738,22 +618,17 @@ export async function graphEnhancedSearchMemories(
 
   if (pprScores.size === 0) return baseResults.slice(0, limit);
 
-  // Step 3: Three-signal RRF merge
   const RRF_K = 60;
-  // Clamp graphWeight to [0, 1] and guard against NaN/Infinity
   const safeWeight = Number.isFinite(graphWeight) ? Math.max(0, Math.min(1, graphWeight)) : 0;
-  const textWeight = 1 - safeWeight; // BM25+vector share this weight
+  const textWeight = 1 - safeWeight;
 
   const scoreMap = new Map<number, { score: number; result: HybridMemoryResult | null }>();
 
-  // BM25+vector signal (from base results, already RRF-fused)
   for (let rank = 0; rank < baseResults.length; rank++) {
     const r = baseResults[rank];
-    const rrfScore = textWeight / (RRF_K + rank + 1);
-    scoreMap.set(r.id, { score: rrfScore, result: r });
+    scoreMap.set(r.id, { score: textWeight / (RRF_K + rank + 1), result: r });
   }
 
-  // PPR graph signal
   const pprRanked = Array.from(pprScores.entries()).sort((a, b) => b[1] - a[1]);
   for (let rank = 0; rank < pprRanked.length; rank++) {
     const [memId] = pprRanked[rank];
@@ -766,8 +641,6 @@ export async function graphEnhancedSearchMemories(
     }
   }
 
-  // Hydrate graph-only hits (PPR discovered memories not in base text results)
-  // Batch-fetch all missing IDs in a single query to avoid N+1 sequential lookups
   const missingIds = Array.from(scoreMap.entries())
     .filter(([, entry]) => entry.result === null)
     .map(([id]) => id);
@@ -801,7 +674,6 @@ export async function graphEnhancedSearchMemories(
     }
   }
 
-  // Sort by combined score, write fused score into similarity, filter out unhydrated entries
   return Array.from(scoreMap.values())
     .filter((e): e is { score: number; result: HybridMemoryResult } => e.result !== null)
     .sort((a, b) => b.score - a.score)
@@ -824,9 +696,7 @@ export function hybridSearchGlobalMemories(
 ): HybridGlobalMemoryResult[] {
   const database = getGlobalDb();
 
-  // 1. BM25 search (post-filter by is_latest)
-  const bm25Index = getGlobalMemoriesBm25Index();
-  const bm25Raw = bm25.search(query, bm25Index, 'docs', limit * 3);
+  const bm25Raw = bm25.search(query, getGlobalMemoriesBm25Index(), 'docs', limit * 3);
   let bm25Results = bm25Raw;
   if (bm25Raw.length > 0) {
     const bm25Ids = bm25Raw.map((r) => r.docId);
@@ -840,7 +710,6 @@ export function hybridSearchGlobalMemories(
     bm25Results = bm25Raw.filter((r) => latestSet.has(r.docId));
   }
 
-  // 2. Vector search — try sqlite-vec first
   type GlobalMemRow = {
     id: number;
     content: string;
@@ -850,121 +719,62 @@ export function hybridSearchGlobalMemories(
     type: string | null;
     created_at: string;
   };
-  let vectorResults: { docId: number; score: number }[] = [];
-  let rowMap: Map<number, GlobalMemRow> = new Map();
 
-  if (sqliteVecAvailable) {
-    try {
-      const candidateLimit = limit * 5;
-      const queryBuffer = floatArrayToBuffer(queryEmbedding);
-      const vecResults = cachedPrepareGlobal(`
-        SELECT m.memory_id AS doc_id, v.distance
-        FROM vec_memories v
-        JOIN vec_memories_map m ON m.vec_rowid = v.rowid
-        WHERE v.embedding MATCH ?
-          AND k = ?
-        ORDER BY v.distance
-      `).all(queryBuffer, candidateLimit) as Array<{ doc_id: number; distance: number }>;
-
-      if (vecResults.length > 0) {
-        const docIds = vecResults.map((r) => r.doc_id);
-        const placeholders = docIds.map(() => '?').join(',');
-
-        let whereClause = `id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
-        const params: any[] = [...docIds];
-        if (since) {
-          whereClause += ' AND created_at >= ?';
-          params.push(since.toISOString());
-        }
-
-        const rows = database
-          .prepare(
-            `
-          SELECT id, content, tags, source, project, type, created_at
-          FROM memories WHERE ${whereClause}
-        `
-          )
-          .all(...params) as GlobalMemRow[];
-
-        rowMap = new Map(rows.map((r) => [r.id, r]));
-        const distanceMap = new Map(vecResults.map((r) => [r.doc_id, r.distance]));
-        for (const row of rows) {
-          const distance = distanceMap.get(row.id) ?? 1;
-          const similarity = 1 - distance;
-          if (similarity >= threshold) {
-            vectorResults.push({ docId: row.id, score: similarity });
-          }
-        }
-        vectorResults.sort((a, b) => b.score - a.score);
+  const pipeline = runHybridPipeline<GlobalMemRow>({
+    queryEmbedding,
+    bm25Results,
+    limit,
+    threshold,
+    alpha,
+    rrfK,
+    prepare: cachedPrepareGlobal,
+    logContext: 'Global',
+    vecQuery: VEC_MEMORIES_QUERY,
+    filterVecRows: (docIds) => {
+      const placeholders = docIds.map(() => '?').join(',');
+      let whereClause = `id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
+      const params: any[] = [...docIds];
+      if (since) {
+        whereClause += ' AND created_at >= ?';
+        params.push(since.toISOString());
       }
-    } catch (error) {
-      logWarn('hybrid-search', 'Global vector search failed, using fallback strategy', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      vectorResults = [];
-    }
-  }
-
-  // Brute-force fallback with safety limit
-  if (vectorResults.length === 0) {
-    let sqlQuery =
-      'SELECT id, content, tags, source, project, type, embedding, created_at FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1';
-    const params: any[] = [];
-    if (since) {
-      sqlQuery += ' AND created_at >= ?';
-      params.push(since.toISOString());
-    }
-    sqlQuery += ` LIMIT ${BRUTE_FORCE_MAX_ROWS}`;
-
-    const rows = database.prepare(sqlQuery).all(...params) as Array<
-      GlobalMemRow & { embedding: Buffer }
-    >;
-
-    if (rows.length === 0) return [];
-    rowMap = new Map(rows.map((r) => [r.id, r]));
-
-    for (const row of rows) {
-      const embedding = bufferToFloatArray(row.embedding);
-      const similarity = cosineSimilarity(queryEmbedding, embedding);
-      if (similarity >= threshold) {
-        vectorResults.push({ docId: row.id, score: similarity });
-      }
-    }
-    vectorResults.sort((a, b) => b.score - a.score);
-  }
-  const topVectorResults = vectorResults.slice(0, limit * 3);
-
-  // 3. Combine using RRF
-  const combined = bm25.reciprocalRankFusion(bm25Results, topVectorResults, alpha, limit, rrfK);
-
-  // 4. Ensure we have all needed rows
-  if (combined.length > 0) {
-    const missingIds = combined.filter((c) => !rowMap.has(c.docId)).map((c) => c.docId);
-    if (missingIds.length > 0) {
-      const placeholders = missingIds.map(() => '?').join(',');
-      const missingRows = database
+      return database
         .prepare(
-          `
-        SELECT id, content, tags, source, project, type, created_at
-        FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1
-      `
+          `SELECT id, content, tags, source, project, type, created_at
+           FROM memories WHERE ${whereClause}`
         )
-        .all(...missingIds) as GlobalMemRow[];
-      for (const row of missingRows) {
-        rowMap.set(row.id, row);
+        .all(...params) as GlobalMemRow[];
+    },
+    loadBruteForceRows: () => {
+      let sql =
+        'SELECT id, content, tags, source, project, type, embedding, created_at FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1';
+      const params: any[] = [];
+      if (since) {
+        sql += ' AND created_at >= ?';
+        params.push(since.toISOString());
       }
-    }
-  }
+      sql += ` LIMIT ${BRUTE_FORCE_MAX_ROWS}`;
+      return database.prepare(sql).all(...params) as (GlobalMemRow & { embedding: Buffer })[];
+    },
+    fetchMissingRows: (ids) => {
+      const placeholders = ids.map(() => '?').join(',');
+      return database
+        .prepare(
+          `SELECT id, content, tags, source, project, type, created_at
+           FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
+        )
+        .all(...ids) as GlobalMemRow[];
+    },
+  });
 
-  const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
-  const vectorMap = new Map(vectorResults.map((r) => [r.docId, r.score]));
+  if (!pipeline || pipeline.combined.length === 0) return [];
 
+  const { combined, rowMap, bm25Map, vectorMap } = pipeline;
   const results: HybridGlobalMemoryResult[] = [];
   for (const c of combined) {
     const row = rowMap.get(c.docId);
     if (!row) continue;
 
-    // Parse and filter by tags if specified
     const rowTags: string[] = parseTags(row.tags);
     if (tags && tags.length > 0) {
       const hasMatchingTag = tags.some((t) =>

--- a/src/lib/db/hybrid-search.ts
+++ b/src/lib/db/hybrid-search.ts
@@ -560,12 +560,17 @@ export function hybridSearchMemories(
         )
         .all(...docIds) as MemoryRow[];
     },
-    loadBruteForceRows: () =>
-      cachedPrepare(
+    loadBruteForceRows: () => {
+      const { count } = cachedPrepare(
+        'SELECT COUNT(*) as count FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1'
+      ).get() as { count: number };
+      if (count > BRUTE_FORCE_MAX_ROWS) return null;
+      return cachedPrepare(
         `SELECT id, content, tags, source, type, created_at, embedding,
                 last_accessed, access_count, valid_from, valid_until, quality_score
          FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1 LIMIT ?`
-      ).all(BRUTE_FORCE_MAX_ROWS) as (MemoryRow & { embedding: Buffer })[],
+      ).all(BRUTE_FORCE_MAX_ROWS) as (MemoryRow & { embedding: Buffer })[];
+    },
     fetchMissingRows: (ids) => {
       const placeholders = ids.map(() => '?').join(',');
       return database
@@ -579,7 +584,37 @@ export function hybridSearchMemories(
     },
   });
 
-  if (!pipeline || pipeline.combined.length === 0) return [];
+  // BM25-only fallback when too many memories for brute-force
+  if (pipeline === null) {
+    const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
+    const docIds = bm25Results.slice(0, limit).map((r) => r.docId);
+    if (docIds.length === 0) return [];
+    const placeholders = docIds.map(() => '?').join(',');
+    const rows = database
+      .prepare(
+        `SELECT id, content, tags, source, type, created_at,
+                last_accessed, access_count, valid_from, valid_until, quality_score
+         FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`
+      )
+      .all(...docIds) as MemoryRow[];
+    return rows.map((row) => ({
+      id: row.id,
+      content: row.content,
+      tags: parseTags(row.tags),
+      source: row.source,
+      type: parseMemoryType(row.type),
+      created_at: row.created_at,
+      similarity: bm25Map.get(row.id) ?? 0,
+      bm25Score: bm25Map.get(row.id),
+      last_accessed: row.last_accessed,
+      access_count: row.access_count,
+      valid_from: row.valid_from,
+      valid_until: row.valid_until,
+      quality_score: row.quality_score,
+    }));
+  }
+
+  if (pipeline.combined.length === 0) return [];
 
   const { combined, rowMap, bm25Map, vectorMap } = pipeline;
   const results: HybridMemoryResult[] = [];
@@ -729,7 +764,7 @@ export function hybridSearchGlobalMemories(
     const bm25Ids = bm25Raw.map((r) => r.docId);
     const placeholders = bm25Ids.map(() => '?').join(',');
     let filterSql = `SELECT id FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
-    const filterParams: any[] = [...bm25Ids];
+    const filterParams: (string | number)[] = [...bm25Ids];
     if (since) {
       filterSql += ' AND created_at >= ?';
       filterParams.push(since.toISOString());
@@ -762,7 +797,7 @@ export function hybridSearchGlobalMemories(
     filterVecRows: (docIds) => {
       const placeholders = docIds.map(() => '?').join(',');
       let whereClause = `id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
-      const params: any[] = [...docIds];
+      const params: (string | number)[] = [...docIds];
       if (since) {
         whereClause += ' AND created_at >= ?';
         params.push(since.toISOString());
@@ -775,13 +810,18 @@ export function hybridSearchGlobalMemories(
         .all(...params) as GlobalMemRow[];
     },
     loadBruteForceRows: () => {
-      let sql =
-        'SELECT id, content, tags, source, project, type, embedding, created_at FROM memories WHERE embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1';
-      const params: any[] = [];
+      let whereClauses = 'embedding IS NOT NULL AND COALESCE(is_latest, 1) = 1';
+      const countParams: (string | number)[] = [];
       if (since) {
-        sql += ' AND created_at >= ?';
-        params.push(since.toISOString());
+        whereClauses += ' AND created_at >= ?';
+        countParams.push(since.toISOString());
       }
+      const { count } = database
+        .prepare(`SELECT COUNT(*) as count FROM memories WHERE ${whereClauses}`)
+        .get(...countParams) as { count: number };
+      if (count > BRUTE_FORCE_MAX_ROWS) return null;
+      let sql = `SELECT id, content, tags, source, project, type, embedding, created_at FROM memories WHERE ${whereClauses}`;
+      const params: (string | number)[] = [...countParams];
       sql += ' LIMIT ?';
       params.push(BRUTE_FORCE_MAX_ROWS);
       return database.prepare(sql).all(...params) as (GlobalMemRow & { embedding: Buffer })[];
@@ -790,7 +830,7 @@ export function hybridSearchGlobalMemories(
       const placeholders = ids.map(() => '?').join(',');
       let sql = `SELECT id, content, tags, source, project, type, created_at
            FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
-      const params: any[] = [...ids];
+      const params: (string | number)[] = [...ids];
       if (since) {
         sql += ' AND created_at >= ?';
         params.push(since.toISOString());
@@ -799,7 +839,46 @@ export function hybridSearchGlobalMemories(
     },
   });
 
-  if (!pipeline || pipeline.combined.length === 0) return [];
+  // BM25-only fallback when too many global memories for brute-force
+  if (pipeline === null) {
+    const bm25Map = new Map(bm25Results.map((r) => [r.docId, r.score]));
+    const docIds = bm25Results.slice(0, limit).map((r) => r.docId);
+    if (docIds.length === 0) return [];
+    const placeholders = docIds.map(() => '?').join(',');
+    let sql = `SELECT id, content, tags, source, project, type, created_at
+         FROM memories WHERE id IN (${placeholders}) AND COALESCE(is_latest, 1) = 1`;
+    const params: (string | number)[] = [...docIds];
+    if (since) {
+      sql += ' AND created_at >= ?';
+      params.push(since.toISOString());
+    }
+    const rows = database.prepare(sql).all(...params) as GlobalMemRow[];
+    const results: HybridGlobalMemoryResult[] = [];
+    for (const row of rows) {
+      const rowTags: string[] = parseTags(row.tags);
+      if (tags && tags.length > 0) {
+        const hasMatchingTag = tags.some((t) =>
+          rowTags.some((rt) => rt.toLowerCase().includes(t.toLowerCase()))
+        );
+        if (!hasMatchingTag) continue;
+      }
+      results.push({
+        id: row.id,
+        content: row.content,
+        tags: rowTags,
+        source: row.source,
+        project: row.project,
+        type: parseMemoryType(row.type),
+        created_at: row.created_at,
+        similarity: bm25Map.get(row.id) ?? 0,
+        bm25Score: bm25Map.get(row.id),
+        isGlobal: true,
+      });
+    }
+    return results;
+  }
+
+  if (pipeline.combined.length === 0) return [];
 
   const { combined, rowMap, bm25Map, vectorMap } = pipeline;
   const results: HybridGlobalMemoryResult[] = [];
@@ -818,7 +897,7 @@ export function hybridSearchGlobalMemories(
     results.push({
       id: row.id,
       content: row.content,
-      tags: parseTags(row.tags),
+      tags: rowTags,
       source: row.source,
       project: row.project,
       type: parseMemoryType(row.type),

--- a/src/lib/storage/backends/postgresql.ts
+++ b/src/lib/storage/backends/postgresql.ts
@@ -286,8 +286,8 @@ export class PostgresBackend {
         return;
       }
       // Safe: queryText is always a source-code string literal when params.length === 0.
-      // Using query object for defensive consistency.
-      const explainResult = await pool.query({ text: 'EXPLAIN ' + queryText });
+      // The params.length === 0 guard above is the real protection against injection.
+      const explainResult = await pool.query('EXPLAIN ' + queryText);
       const plan = explainResult.rows.map((r) => Object.values(r)[0]).join('\n');
       logWarn('postgresql', `Slow query (${durationMs}ms):\n${queryText}\nEXPLAIN:\n${plan}`);
     } catch (error) {

--- a/src/lib/storage/backends/postgresql.ts
+++ b/src/lib/storage/backends/postgresql.ts
@@ -279,14 +279,15 @@ export class PostgresBackend {
     }
     this.lastSlowQueryLogMs = now;
 
+    // Log slow query with EXPLAIN plan when safe (no user-supplied params)
     try {
-      // When params are present, skip EXPLAIN to avoid inlining sensitive
-      // values (embeddings, project IDs) into log output.
       if (params.length > 0) {
         logWarn('postgresql', `Slow query (${durationMs}ms)`, { query: queryText });
         return;
       }
-      const explainResult = await pool.query(`EXPLAIN ${queryText}`);
+      // Safe: queryText is always a source-code string literal when params.length === 0.
+      // Using query object for defensive consistency.
+      const explainResult = await pool.query({ text: 'EXPLAIN ' + queryText });
       const plan = explainResult.rows.map((r) => Object.values(r)[0]).join('\n');
       logWarn('postgresql', `Slow query (${durationMs}ms):\n${queryText}\nEXPLAIN:\n${plan}`);
     } catch (error) {

--- a/src/lib/undercover.ts
+++ b/src/lib/undercover.ts
@@ -58,6 +58,20 @@ Write code the way a human developer would. Specifically:
 - Match the codebase's existing naming conventions, formatting, and idiom density.
 - If the project has sparse comments, write sparse comments. If verbose, match that.
 
+## Natural Language Style (anti-AI fingerprinting)
+AI-generated text has recognizable stylistic tells. Avoid ALL of these:
+- **Em dashes** (\u2014), en dashes (\u2013): use commas, parentheses, or split into two sentences instead
+- **Filler openers**: "Certainly!", "Great question!", "Sure!", "Absolutely!", "I'd be happy to"
+- **Hedge stacking**: "It's worth noting that", "It should be mentioned that", "Interestingly,"
+- **Overly structured lists** in commit messages or PR descriptions where prose would be natural
+- **Resumptive phrasing**: "As mentioned above", "To summarize", "In conclusion"
+- **Corporate passive voice**: "It was determined that" instead of "I found" or "We found"
+- **Excessive qualifiers**: "robust", "seamless", "comprehensive", "leverage", "utilize", "facilitate"
+- **Paired conjunctions overuse**: "both X and Y", "not only X but also Y" in every other sentence
+
+Write the way a tired developer writes at 2am: short, direct, no flourishes.
+Dashes in code (hyphens in CLI flags, minus signs, etc.) are fine — only typographic em/en dashes in prose are banned.
+
 ## Issue Comments
 Write issue and PR review comments as a developer, not an assistant.
 No "I'd be happy to help" or "Here's what I found" phrasing.
@@ -77,7 +91,8 @@ BAD commit messages:
 export const UNDERCOVER_COMMIT_REMINDER = `<undercover-reminder>
 UNDERCOVER: No AI attribution, no "Generated with", no "Co-Authored-By", no tool names, no AI labels.
 No AI-revealing branch names (claude/, copilot/, ai/).
-Write as a human developer. Match existing project style.
+No em dashes, no en dashes, no "Certainly!", no corporate filler. Write like a human dev.
+Match existing project style.
 </undercover-reminder>`;
 
 // ─── State Types ────────────────────────────────────────────────────

--- a/src/lib/undercover.ts
+++ b/src/lib/undercover.ts
@@ -70,7 +70,7 @@ AI-generated text has recognizable stylistic tells. Avoid ALL of these:
 - **Paired conjunctions overuse**: "both X and Y", "not only X but also Y" in every other sentence
 
 Write the way a tired developer writes at 2am: short, direct, no flourishes.
-Dashes in code (hyphens in CLI flags, minus signs, etc.) are fine — only typographic em/en dashes in prose are banned.
+Dashes in code (hyphens in CLI flags, minus signs, etc.) are fine - only typographic em/en dashes in prose are banned.
 
 ## Issue Comments
 Write issue and PR review comments as a developer, not an assistant.


### PR DESCRIPTION
## Summary

- **CORS**: Replace wildcard `Access-Control-Allow-Origin: *` with localhost-only origin check on daemon HTTP server
- **Auth token**: Per-instance 32-byte hex token on daemon start, written to `.succ/.tmp/daemon.token` (mode 0600), verified via `Authorization: Bearer` header with constant-time comparison. Public endpoints (`/health`, `/api/status`, `/api/version`) remain unauthenticated for discovery.
- **Client + hooks**: All 10 hook files and the TS client updated to auto-inject auth token via `daemonFetch` wrapper / `buildAuthHeaders` helper
- **EXPLAIN injection**: Use pg query object instead of string interpolation
- **Hybrid search refactor**: Extract shared `runHybridPipeline<TRow>` generic, deduplicating ~85% repeated logic across Code/Docs/Memories/Global search functions
- **Hybrid search fixes**: Add COUNT(*) check + BM25-only fallback to memories and global memories (was missing, unlike code/docs). Replace `any[]` with `(string | number)[]` for filter params. Remove duplicate `parseTags()` call.
- **Undercover mode**: Gate `includeCoAuthoredBy` on undercover flag in pre-tool hook. Add anti-AI fingerprinting rules (em/en dash ban, filler phrases, corporate qualifiers, hedge stacking).

## Test plan

- [ ] Daemon starts, writes port + token files
- [ ] Unauthenticated request to `/api/recall` returns 401
- [ ] Health check (`/health`) succeeds without token
- [ ] Hooks auto-discover and send token via `daemonFetch`
- [ ] Hybrid search results unchanged for code/docs
- [ ] Memories/global memories gracefully fall back to BM25-only when row count exceeds threshold
- [ ] Shutdown removes token file
- [ ] With `undercover: true`, no commit-format block injected by hooks
- [ ] Undercover session block includes anti-AI fingerprinting section